### PR TITLE
[DASH] Add support for ENI Counters

### DIFF
--- a/meta/SaiSerialize.cpp
+++ b/meta/SaiSerialize.cpp
@@ -1041,6 +1041,14 @@ std::string sai_serialize_buffer_pool_stat(
     return sai_serialize_enum(counter, &sai_metadata_enum_sai_buffer_pool_stat_t);
 }
 
+std::string sai_serialize_eni_stat(
+        _In_ const sai_eni_stat_t counter)
+{
+    SWSS_LOG_ENTER();
+
+    return sai_serialize_enum(counter, &sai_metadata_enum_sai_eni_stat_t);
+}
+
 std::string sai_serialize_tunnel_stat(
         _In_ const sai_tunnel_stat_t counter)
 {

--- a/meta/sai_serialize.h
+++ b/meta/sai_serialize.h
@@ -122,6 +122,9 @@ std::string sai_serialize_ingress_priority_group_attr(
 std::string sai_serialize_buffer_pool_stat(
         _In_ const sai_buffer_pool_stat_t counter);
 
+std::string sai_serialize_eni_stat(
+        _In_ const sai_eni_stat_t counter);
+
 std::string sai_serialize_tunnel_stat(
         _In_ const sai_tunnel_stat_t counter);
 

--- a/unittest/syncd/TestFlexCounter.cpp
+++ b/unittest/syncd/TestFlexCounter.cpp
@@ -1,10 +1,13 @@
 #include "FlexCounter.h"
 #include "MockableSaiInterface.h"
 #include "MockHelper.h"
-
+#include "VirtualObjectIdManager.h"
+#include "NumberOidIndexGenerator.h"
+#include <string>
 #include <gtest/gtest.h>
 
-
+using namespace saimeta;
+using namespace sairedis;
 using namespace syncd;
 using namespace std;
 
@@ -39,8 +42,42 @@ std::string toOid(T value)
 std::shared_ptr<MockableSaiInterface> sai(new MockableSaiInterface());
 typedef std::function<void(swss::Table &countersTable, const std::string& key, const std::vector<std::string>& counterIdNames, const std::vector<std::string>& expectedValues)> VerifyStatsFunc;
 
+std::vector<sai_object_id_t> generateOids(
+        unsigned int numOid,
+        sai_object_type_t object_type)
+{
+    SWSS_LOG_ENTER();
+
+    std::vector<sai_object_id_t> object_ids;
+    if (!numOid)
+        return object_ids;
+
+    auto scc = std::make_shared<SwitchConfigContainer>();
+    for (unsigned int i = 0; i < numOid; i++){
+        auto hw_info = "asic" + std::to_string(i);
+        scc->insert(std::make_shared<SwitchConfig>(i, hw_info));
+    }
+
+    auto vidManager = VirtualObjectIdManager(0, scc, std::make_shared<NumberOidIndexGenerator>());
+    if (object_type == SAI_OBJECT_TYPE_SWITCH)
+    {
+        for (unsigned int i = 0; i < numOid; i++){
+            auto hw_info = "asic" + std::to_string(i);
+            object_ids.push_back(vidManager.allocateNewSwitchObjectId(hw_info));
+        }
+    }
+    else
+    {
+        auto sid = vidManager.allocateNewSwitchObjectId("asic0");
+        for (unsigned int i = 0; i < numOid; i++){
+            object_ids.push_back(vidManager.allocateNewObjectId(object_type, sid));
+        }
+    }
+    return object_ids;
+}
+
 void testAddRemoveCounter(
-        const std::vector<sai_object_id_t>& object_ids,
+        unsigned int numOid,
         sai_object_type_t object_type,
         const std::string& counterIdFieldName,
         const std::vector<std::string>& counterIdNames,
@@ -54,6 +91,9 @@ void testAddRemoveCounter(
     FlexCounter fc("test", sai, "COUNTERS_DB");
 
     test_syncd::mockVidManagerObjectTypeQuery(object_type);
+
+    std::vector<sai_object_id_t> object_ids = generateOids(numOid, object_type);
+    EXPECT_EQ(object_ids.size(), numOid);
 
     std::vector<swss::FieldValueTuple> values;
     values.emplace_back(POLL_INTERVAL_FIELD, "1000");
@@ -136,7 +176,7 @@ TEST(FlexCounter, addRemoveCounter)
     };
 
     testAddRemoveCounter(
-        {sai_object_id_t(0x54000000000000)},
+        1,
         SAI_OBJECT_TYPE_COUNTER,
         FLOW_COUNTER_ID_LIST,
         {"SAI_COUNTER_STAT_PACKETS", "SAI_COUNTER_STAT_BYTES"},
@@ -145,7 +185,7 @@ TEST(FlexCounter, addRemoveCounter)
         true);
 
     testAddRemoveCounter(
-        {sai_object_id_t(0x5a000000000000)},
+        1,
         SAI_OBJECT_TYPE_MACSEC_FLOW,
         MACSEC_FLOW_COUNTER_ID_LIST,
         {"SAI_MACSEC_FLOW_STAT_CONTROL_PKTS", "SAI_MACSEC_FLOW_STAT_PKTS_UNTAGGED"},
@@ -154,7 +194,7 @@ TEST(FlexCounter, addRemoveCounter)
         false);
 
     testAddRemoveCounter(
-        {sai_object_id_t(0x5c000000000000)},
+        1,
         SAI_OBJECT_TYPE_MACSEC_SA,
         MACSEC_SA_COUNTER_ID_LIST,
         {"SAI_MACSEC_SA_STAT_OCTETS_ENCRYPTED", "SAI_MACSEC_SA_STAT_OCTETS_PROTECTED"},
@@ -163,7 +203,7 @@ TEST(FlexCounter, addRemoveCounter)
         false);
 
     testAddRemoveCounter(
-        {sai_object_id_t(0x1000000000000)},
+        1,
         SAI_OBJECT_TYPE_PORT,
         PORT_COUNTER_ID_LIST,
         {"SAI_PORT_STAT_IF_IN_OCTETS", "SAI_PORT_STAT_IF_IN_UCAST_PKTS"},
@@ -172,7 +212,7 @@ TEST(FlexCounter, addRemoveCounter)
         false);
 
     testAddRemoveCounter(
-        {sai_object_id_t(0x1000000000000)},
+        1,
         SAI_OBJECT_TYPE_PORT,
         PORT_DEBUG_COUNTER_ID_LIST,
         {"SAI_PORT_STAT_IN_CONFIGURED_DROP_REASONS_0_DROPPED_PKTS", "SAI_PORT_STAT_IN_CONFIGURED_DROP_REASONS_1_DROPPED_PKTS"},
@@ -185,9 +225,9 @@ TEST(FlexCounter, addRemoveCounter)
         clearCalled = true;
         return SAI_STATUS_SUCCESS;
     };
-
+ 
     testAddRemoveCounter(
-        {sai_object_id_t(0x15000000000000)},
+        1,
         SAI_OBJECT_TYPE_QUEUE,
         QUEUE_COUNTER_ID_LIST,
         {"SAI_QUEUE_STAT_PACKETS", "SAI_QUEUE_STAT_BYTES"},
@@ -198,7 +238,7 @@ TEST(FlexCounter, addRemoveCounter)
     EXPECT_EQ(true, clearCalled);
 
     testAddRemoveCounter(
-        {sai_object_id_t(0x1a000000000000)},
+        1,
         SAI_OBJECT_TYPE_INGRESS_PRIORITY_GROUP,
         PG_COUNTER_ID_LIST,
         {"SAI_INGRESS_PRIORITY_GROUP_STAT_PACKETS", "SAI_INGRESS_PRIORITY_GROUP_STAT_BYTES"},
@@ -207,7 +247,7 @@ TEST(FlexCounter, addRemoveCounter)
         false);
 
     testAddRemoveCounter(
-        {sai_object_id_t(0x6000000000000)},
+        1,
         SAI_OBJECT_TYPE_ROUTER_INTERFACE,
         RIF_COUNTER_ID_LIST,
         {"SAI_ROUTER_INTERFACE_STAT_IN_OCTETS", "SAI_ROUTER_INTERFACE_STAT_IN_PACKETS"},
@@ -216,7 +256,7 @@ TEST(FlexCounter, addRemoveCounter)
         false);
 
     testAddRemoveCounter(
-        {sai_object_id_t(0x21000000000000)},
+        1,
         SAI_OBJECT_TYPE_SWITCH,
         SWITCH_DEBUG_COUNTER_ID_LIST,
         {"SAI_SWITCH_STAT_IN_CONFIGURED_DROP_REASONS_0_DROPPED_PKTS", "SAI_SWITCH_STAT_IN_CONFIGURED_DROP_REASONS_1_DROPPED_PKTS"},
@@ -225,7 +265,7 @@ TEST(FlexCounter, addRemoveCounter)
         false);
 
     testAddRemoveCounter(
-        {sai_object_id_t(0x2a000000000000)},
+        1,
         SAI_OBJECT_TYPE_TUNNEL,
         TUNNEL_COUNTER_ID_LIST,
         {"SAI_TUNNEL_STAT_IN_OCTETS", "SAI_TUNNEL_STAT_IN_PACKETS"},
@@ -233,9 +273,18 @@ TEST(FlexCounter, addRemoveCounter)
         counterVerifyFunc,
         false);
 
+    testAddRemoveCounter(
+        1,
+        (sai_object_type_t)SAI_OBJECT_TYPE_ENI,
+        ENI_COUNTER_ID_LIST,
+        {"SAI_ENI_STAT_FLOW_CREATED", "SAI_ENI_STAT_FLOW_CREATE_FAILED", "SAI_ENI_STAT_FLOW_DELETED", "SAI_ENI_STAT_FLOW_DELETE_FAILED"},
+        {"100", "200", "300", "400"},
+        counterVerifyFunc,
+        false);
+
     clearCalled = false;
     testAddRemoveCounter(
-        {sai_object_id_t(0x18000000000000)},
+        1,
         SAI_OBJECT_TYPE_BUFFER_POOL,
         BUFFER_POOL_COUNTER_ID_LIST,
         {"SAI_BUFFER_POOL_STAT_CURR_OCCUPANCY_BYTES", "SAI_BUFFER_POOL_STAT_WATERMARK_BYTES"},
@@ -256,7 +305,7 @@ TEST(FlexCounter, addRemoveCounter)
     };
 
     testAddRemoveCounter(
-        {sai_object_id_t(0x15000000000000)},
+        1,
         SAI_OBJECT_TYPE_QUEUE,
         QUEUE_ATTR_ID_LIST,
         {"SAI_QUEUE_ATTR_PAUSE_STATUS"},
@@ -276,7 +325,7 @@ TEST(FlexCounter, addRemoveCounter)
     };
 
     testAddRemoveCounter(
-        {sai_object_id_t(0x1a000000000000)},
+        1,
         SAI_OBJECT_TYPE_INGRESS_PRIORITY_GROUP,
         PG_ATTR_ID_LIST,
         {"SAI_INGRESS_PRIORITY_GROUP_ATTR_PORT"},
@@ -300,7 +349,7 @@ TEST(FlexCounter, addRemoveCounter)
     };
 
     testAddRemoveCounter(
-        {sai_object_id_t(0x5c000000000000)},
+        1,
         SAI_OBJECT_TYPE_MACSEC_SA,
         MACSEC_SA_ATTR_ID_LIST,
         {"SAI_MACSEC_SA_ATTR_CONFIGURED_EGRESS_XPN", "SAI_MACSEC_SA_ATTR_AN"},
@@ -320,7 +369,7 @@ TEST(FlexCounter, addRemoveCounter)
     };
 
     testAddRemoveCounter(
-        {sai_object_id_t(0x9000000000000)},
+        1,
         SAI_OBJECT_TYPE_ACL_COUNTER,
         ACL_COUNTER_ATTR_ID_LIST,
         {"SAI_ACL_COUNTER_ATTR_PACKETS"},
@@ -373,7 +422,7 @@ TEST(FlexCounter, queryCounterCapability)
     };
 
     testAddRemoveCounter(
-        {sai_object_id_t(0x1000000000000)},
+        1,
         SAI_OBJECT_TYPE_PORT,
         PORT_COUNTER_ID_LIST,
         {"SAI_PORT_STAT_IF_IN_OCTETS", "SAI_PORT_STAT_IF_IN_UCAST_PKTS"},
@@ -586,7 +635,7 @@ TEST(FlexCounter, bulkCounter)
     };
 
     testAddRemoveCounter(
-        {sai_object_id_t(0x54000000000000), sai_object_id_t(0x54000000000001)},
+        2,
         SAI_OBJECT_TYPE_COUNTER,
         FLOW_COUNTER_ID_LIST,
         {"SAI_COUNTER_STAT_PACKETS", "SAI_COUNTER_STAT_BYTES"},
@@ -595,7 +644,7 @@ TEST(FlexCounter, bulkCounter)
         true);
 
     testAddRemoveCounter(
-        {sai_object_id_t(0x5a000000000000), sai_object_id_t(0x5a000000000001)},
+        2,
         SAI_OBJECT_TYPE_MACSEC_FLOW,
         MACSEC_FLOW_COUNTER_ID_LIST,
         {"SAI_MACSEC_FLOW_STAT_CONTROL_PKTS", "SAI_MACSEC_FLOW_STAT_PKTS_UNTAGGED"},
@@ -604,7 +653,7 @@ TEST(FlexCounter, bulkCounter)
         false);
 
     testAddRemoveCounter(
-        {sai_object_id_t(0x5c000000000000), sai_object_id_t(0x5c000000000001)},
+        2,
         SAI_OBJECT_TYPE_MACSEC_SA,
         MACSEC_SA_COUNTER_ID_LIST,
         {"SAI_MACSEC_SA_STAT_OCTETS_ENCRYPTED", "SAI_MACSEC_SA_STAT_OCTETS_PROTECTED"},
@@ -613,7 +662,7 @@ TEST(FlexCounter, bulkCounter)
         false);
 
     testAddRemoveCounter(
-        {sai_object_id_t(0x1000000000000), sai_object_id_t(0x1000000000001)},
+        2,
         SAI_OBJECT_TYPE_PORT,
         PORT_COUNTER_ID_LIST,
         {"SAI_PORT_STAT_IF_IN_OCTETS", "SAI_PORT_STAT_IF_IN_UCAST_PKTS"},
@@ -622,7 +671,7 @@ TEST(FlexCounter, bulkCounter)
         false);
 
     testAddRemoveCounter(
-        {sai_object_id_t(0x1000000000000), sai_object_id_t(0x1000000000001)},
+        2,
         SAI_OBJECT_TYPE_PORT,
         PORT_DEBUG_COUNTER_ID_LIST,
         {"SAI_PORT_STAT_IN_CONFIGURED_DROP_REASONS_0_DROPPED_PKTS", "SAI_PORT_STAT_IN_CONFIGURED_DROP_REASONS_1_DROPPED_PKTS"},
@@ -631,7 +680,7 @@ TEST(FlexCounter, bulkCounter)
         false);
 
     testAddRemoveCounter(
-        {sai_object_id_t(0x15000000000000), sai_object_id_t(0x15000000000001)},
+        2,
         SAI_OBJECT_TYPE_QUEUE,
         QUEUE_COUNTER_ID_LIST,
         {"SAI_QUEUE_STAT_PACKETS", "SAI_QUEUE_STAT_BYTES"},
@@ -642,7 +691,7 @@ TEST(FlexCounter, bulkCounter)
     EXPECT_EQ(true, clearCalled);
 
     testAddRemoveCounter(
-        {sai_object_id_t(0x1a000000000000), sai_object_id_t(0x1a000000000001)},
+        2,
         SAI_OBJECT_TYPE_INGRESS_PRIORITY_GROUP,
         PG_COUNTER_ID_LIST,
         {"SAI_INGRESS_PRIORITY_GROUP_STAT_PACKETS", "SAI_INGRESS_PRIORITY_GROUP_STAT_BYTES"},
@@ -651,7 +700,7 @@ TEST(FlexCounter, bulkCounter)
         false);
 
     testAddRemoveCounter(
-        {sai_object_id_t(0x6000000000000), sai_object_id_t(0x6000000000001)},
+        2,
         SAI_OBJECT_TYPE_ROUTER_INTERFACE,
         RIF_COUNTER_ID_LIST,
         {"SAI_ROUTER_INTERFACE_STAT_IN_OCTETS", "SAI_ROUTER_INTERFACE_STAT_IN_PACKETS"},
@@ -660,7 +709,7 @@ TEST(FlexCounter, bulkCounter)
         false);
 
     testAddRemoveCounter(
-        {sai_object_id_t(0x21000000000000), sai_object_id_t(0x21000000000001)},
+        2,
         SAI_OBJECT_TYPE_SWITCH,
         SWITCH_DEBUG_COUNTER_ID_LIST,
         {"SAI_SWITCH_STAT_IN_CONFIGURED_DROP_REASONS_0_DROPPED_PKTS", "SAI_SWITCH_STAT_IN_CONFIGURED_DROP_REASONS_1_DROPPED_PKTS"},
@@ -669,7 +718,7 @@ TEST(FlexCounter, bulkCounter)
         false);
 
     testAddRemoveCounter(
-        {sai_object_id_t(0x2a000000000000), sai_object_id_t(0x2a000000000001)},
+        2,
         SAI_OBJECT_TYPE_TUNNEL,
         TUNNEL_COUNTER_ID_LIST,
         {"SAI_TUNNEL_STAT_IN_OCTETS", "SAI_TUNNEL_STAT_IN_PACKETS"},
@@ -677,9 +726,18 @@ TEST(FlexCounter, bulkCounter)
         counterVerifyFunc,
         false);
 
+    testAddRemoveCounter(
+        2,
+        (sai_object_type_t)SAI_OBJECT_TYPE_ENI,
+        ENI_COUNTER_ID_LIST,
+        {"SAI_ENI_STAT_FLOW_CREATED", "SAI_ENI_STAT_FLOW_CREATE_FAILED", "SAI_ENI_STAT_FLOW_DELETED", "SAI_ENI_STAT_FLOW_DELETE_FAILED"},
+        {"100", "200", "300", "400"},
+        counterVerifyFunc,
+        false);
+
     clearCalled = false;
     testAddRemoveCounter(
-        {sai_object_id_t(0x18000000000000), sai_object_id_t(0x18000000000001)},
+        2,
         SAI_OBJECT_TYPE_BUFFER_POOL,
         BUFFER_POOL_COUNTER_ID_LIST,
         {"SAI_BUFFER_POOL_STAT_CURR_OCCUPANCY_BYTES", "SAI_BUFFER_POOL_STAT_WATERMARK_BYTES"},


### PR DESCRIPTION
1) Add support for DASH ENI Flex Counter and added a UT
2) Refactored the Flexcounter UT to not use hardcoded oid and instead generate in the test based on object type. 

```
Note: Google Test filter = *FlexCounter*

[==========] Running 7 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 7 tests from FlexCounter
[ RUN      ] FlexCounter.addRemoveCounter
[       OK ] FlexCounter.addRemoveCounter (16804 ms)
[ RUN      ] FlexCounter.queryCounterCapability
[       OK ] FlexCounter.queryCounterCapability (1050 ms)
[ RUN      ] FlexCounter.noSupportedCounters
[       OK ] FlexCounter.noSupportedCounters (0 ms)
[ RUN      ] FlexCounter.addRemoveCounterPlugin
[       OK ] FlexCounter.addRemoveCounterPlugin (1 ms)
[ RUN      ] FlexCounter.addRemoveCounterForPort
[       OK ] FlexCounter.addRemoveCounterForPort (2000 ms)
[ RUN      ] FlexCounter.bulkCounter
[       OK ] FlexCounter.bulkCounter (12604 ms)
[ RUN      ] FlexCounter.counterIdChange
[       OK ] FlexCounter.counterIdChange (6300 ms)
[----------] 7 tests from FlexCounter (38760 ms total)

[----------] Global test environment tear-down
[==========] 7 tests from 1 test suite ran. (38761 ms total)
[  PASSED ] 7 tests.

```