### PR TITLE
[FC] Fix the update failure in switch debug counters

### DIFF
--- a/syncd/FlexCounter.cpp
+++ b/syncd/FlexCounter.cpp
@@ -1005,6 +1005,12 @@ public:
                         {
                             counter_data->setStatsMode(instance_stats_mode);
                         }
+                        auto it_vid = m_objectIdsMap.find(vid);
+                        if (it_vid != m_objectIdsMap.end())
+                        {
+                            // Remove and re-add if vid already exists
+                            m_objectIdsMap.erase(it_vid);
+                        }
                         m_objectIdsMap.emplace(vid, counter_data);
                     }
                 }


### PR DESCRIPTION
DropCouter updates are not honoured and only the first counter is polled.

**Steps to repro:**
```
config dropcounters install COUNTER_SMAC_MULTICAST SWITCH_INGRESS_DROPS [SMAC_MULTICAST]
config dropcounters install COUNTER_SMAC_EQUALS_DMAC SWITCH_INGRESS_DROPS [SMAC_EQUALS_DMAC]
```

**Observed Behavior:**
```
sonic-db-cli COUNTERS_DB hgetall "COUNTERS_DEBUG_NAME_SWITCH_STAT_MAP"
{'COUNTER_SMAC_MULTICAST': 'SAI_SWITCH_STAT_IN_CONFIGURED_DROP_REASONS_0_DROPPED_PKTS', 'COUNTER_SMAC_EQUALS_DMAC': 'SAI_SWITCH_STAT_IN_CONFIGURED_DROP_REASONS_1_DROPPED_PKTS'}

<Only the first counter is being polled, others are not honored>
sonic-db-cli COUNTERS_DB hgetall "COUNTERS:oid:0x21000000000000"
{'SAI_SWITCH_STAT_IN_CONFIGURED_DROP_REASONS_0_DROPPED_PKTS': '0'}

<After the Fix:>
sonic-db-cli COUNTERS_DB hgetall "COUNTERS:oid:0x21000000000000"
{'SAI_SWITCH_STAT_IN_CONFIGURED_DROP_REASONS_0_DROPPED_PKTS': '0', 'SAI_SWITCH_STAT_IN_CONFIGURED_DROP_REASONS_1_DROPPED_PKTS': '0'}
```

Happening because map.emplace on an existing object is a no-op


