### PR TITLE
[Zmq] Accomodate large bulk calls

### DIFF
--- a/lib/ZeroMQChannel.cpp
+++ b/lib/ZeroMQChannel.cpp
@@ -12,7 +12,7 @@
 
 using namespace sairedis;
 
-#define ZMQ_RESPONSE_BUFFER_SIZE (4*1024*1024)
+#define ZMQ_RESPONSE_BUFFER_SIZE (64*1024*1024)
 #define ZMQ_MAX_RETRY 10
 
 ZeroMQChannel::ZeroMQChannel(

--- a/meta/ZeroMQSelectableChannel.cpp
+++ b/meta/ZeroMQSelectableChannel.cpp
@@ -6,7 +6,7 @@
 #include <zmq.h>
 #include <unistd.h>
 
-#define ZMQ_RESPONSE_BUFFER_SIZE (4*1024*1024)
+#define ZMQ_RESPONSE_BUFFER_SIZE (64*1024*1024)
 
 //#define ZMQ_POLL_TIMEOUT (2*60*1000)
 #define ZMQ_POLL_TIMEOUT (1000)


### PR DESCRIPTION
Increase ZMQ Recv/response buffer size to 64 MB to accomodate bulk sizes of upto 65536 for types CA2PA, OUTBOUND ROUTES and PA Validation