### PR TITLE
[DPU] Add support for Flow bulk session get notifications

### DIFF
--- a/meta/Makefile.am
+++ b/meta/Makefile.am
@@ -39,6 +39,7 @@ libsaimeta_la_SOURCES = \
 				NotificationIcmpEchoSessionStateChange.cpp \
 				NotificationHaSetEvent.cpp \
 				NotificationHaScopeEvent.cpp \
+				NotificationFlowBulkGetSessionEvent.cpp \
 				NotificationTwampSessionEvent.cpp \
 				NotificationPortHostTxReadyEvent.cpp \
 				NotificationTamTelTypeConfigChange.cpp \

--- a/meta/Meta.cpp
+++ b/meta/Meta.cpp
@@ -7246,31 +7246,19 @@ void Meta::meta_sai_on_flow_bulk_get_session_event(
         return;
     }
 
-    // Process the flow_bulk_session_id once, then process each event data
     if (flow_bulk_session_id != SAI_NULL_OBJECT_ID)
     {
-        // Validate and track the flow_bulk_session_id object
         auto ot = objectTypeQuery(flow_bulk_session_id);
 
-        bool valid = false;
-
-        switch ((int)ot)
+        if (ot != SAI_OBJECT_TYPE_FLOW_ENTRY_BULK_GET_SESSION)
         {
-            // TODO hardcoded types, must advance SAI repository commit to get metadata for this
-            case SAI_OBJECT_TYPE_FLOW_ENTRY_BULK_GET_SESSION:
-
-                valid = true;
-                break;
-
-            default:
-
-                SWSS_LOG_ERROR("flow_bulk_session_id %s has unexpected type: %s, expected FLOW_ENTRY_BULK_GET_SESSION",
-                        sai_serialize_object_id(flow_bulk_session_id).c_str(),
-                        sai_serialize_object_type(ot).c_str());
-                break;
+            SWSS_LOG_ERROR("flow_bulk_session_id %s has unexpected type: %s",
+                    sai_serialize_object_id(flow_bulk_session_id).c_str(),
+                    sai_serialize_object_type(ot).c_str());
+            return ;
         }
 
-        if (valid && !m_oids.objectReferenceExists(flow_bulk_session_id))
+        if (!m_oids.objectReferenceExists(flow_bulk_session_id))
         {
             SWSS_LOG_NOTICE("flow_bulk_session_id new object spotted %s not present in local DB (snoop!)",
                     sai_serialize_object_id(flow_bulk_session_id).c_str());

--- a/meta/Meta.h
+++ b/meta/Meta.h
@@ -266,6 +266,11 @@ namespace saimeta
                     _In_ uint32_t count,
                     _In_ const sai_twamp_session_event_notification_data_t *data);
 
+            void meta_sai_on_flow_bulk_get_session_event(
+                    _In_ sai_object_id_t flow_bulk_session_id,
+                    _In_ uint32_t count,
+                    _In_ const sai_flow_bulk_get_session_event_data_t *data);
+
             void meta_sai_on_tam_tel_type_config_change(_In_ sai_object_id_t m_tam_id);
 
     private: // notifications helpers

--- a/meta/NotificationFactory.cpp
+++ b/meta/NotificationFactory.cpp
@@ -13,6 +13,7 @@
 #include "NotificationTamTelTypeConfigChange.h"
 #include "NotificationHaSetEvent.h"
 #include "NotificationHaScopeEvent.h"
+#include "NotificationFlowBulkGetSessionEvent.h"
 #include "NotificationSwitchMacsecPostStatus.h"
 #include "NotificationMacsecPostStatus.h"
 #include "sairediscommon.h"
@@ -62,6 +63,9 @@ std::shared_ptr<Notification> NotificationFactory::deserialize(
 
     if (name == SAI_SWITCH_NOTIFICATION_NAME_HA_SCOPE_EVENT)
         return std::make_shared<NotificationHaScopeEvent>(serializedNotification);
+
+    if (name == SAI_SWITCH_NOTIFICATION_NAME_FLOW_BULK_GET_SESSION_EVENT)
+        return std::make_shared<NotificationFlowBulkGetSessionEvent>(serializedNotification);
 
     if (name == SAI_SWITCH_NOTIFICATION_NAME_TWAMP_SESSION_EVENT)
         return std::make_shared<NotificationTwampSessionEvent>(serializedNotification);

--- a/meta/NotificationFlowBulkGetSessionEvent.cpp
+++ b/meta/NotificationFlowBulkGetSessionEvent.cpp
@@ -1,0 +1,79 @@
+#include "NotificationFlowBulkGetSessionEvent.h"
+
+#include "swss/logger.h"
+
+#include "meta/sai_serialize.h"
+#include "sairediscommon.h"
+
+using namespace sairedis;
+
+NotificationFlowBulkGetSessionEvent::NotificationFlowBulkGetSessionEvent(
+        _In_ const std::string& serializeNotification):
+    Notification(
+        SAI_SWITCH_NOTIFICATION_TYPE_FLOW_BULK_GET_SESSION_EVENT,
+        serializeNotification),
+    m_flow_bulk_session_id(SAI_NULL_OBJECT_ID),
+    m_count(0),
+    m_data(nullptr)
+{
+    SWSS_LOG_ENTER();
+
+    sai_deserialize_flow_bulk_get_session_event_ntf(
+        serializeNotification,
+        m_flow_bulk_session_id,
+        m_count,
+        &m_data);
+}
+
+NotificationFlowBulkGetSessionEvent::~NotificationFlowBulkGetSessionEvent()
+{
+    SWSS_LOG_ENTER();
+
+    sai_deserialize_free_flow_bulk_get_session_event_ntf(m_count, m_data);
+}
+
+sai_object_id_t NotificationFlowBulkGetSessionEvent::getSwitchId() const
+{
+    SWSS_LOG_ENTER();
+
+    // Flow bulk get session event does not have switch id directly
+    // We can extract it from flow_bulk_session_id if needed
+    return SAI_NULL_OBJECT_ID;
+}
+
+sai_object_id_t NotificationFlowBulkGetSessionEvent::getAnyObjectId() const
+{
+    SWSS_LOG_ENTER();
+
+    if (m_flow_bulk_session_id != SAI_NULL_OBJECT_ID)
+    {
+        return m_flow_bulk_session_id;
+    }
+
+    return SAI_NULL_OBJECT_ID;
+}
+
+void NotificationFlowBulkGetSessionEvent::processMetadata(
+        _In_ std::shared_ptr<saimeta::Meta> meta) const
+{
+    SWSS_LOG_ENTER();
+
+    // For flow bulk get session event, we don't need to process metadata
+    // since we're only handling FINISHED events which don't contain flow entries
+    // If needed in the future, we can add meta_sai_on_flow_bulk_get_session_event here
+}
+
+void NotificationFlowBulkGetSessionEvent::executeCallback(
+        _In_ const sai_switch_notifications_t& switchNotifications) const
+{
+    SWSS_LOG_ENTER();
+
+    if (switchNotifications.on_flow_bulk_get_session_event)
+    {
+        switchNotifications.on_flow_bulk_get_session_event(
+                m_flow_bulk_session_id,
+                m_count,
+                m_data);
+    }
+}
+

--- a/meta/NotificationFlowBulkGetSessionEvent.cpp
+++ b/meta/NotificationFlowBulkGetSessionEvent.cpp
@@ -58,9 +58,10 @@ void NotificationFlowBulkGetSessionEvent::processMetadata(
 {
     SWSS_LOG_ENTER();
 
-    // For flow bulk get session event, we don't need to process metadata
-    // since we're only handling FINISHED events which don't contain flow entries
-    // If needed in the future, we can add meta_sai_on_flow_bulk_get_session_event here
+    meta->meta_sai_on_flow_bulk_get_session_event(
+            m_flow_bulk_session_id,
+            m_count,
+            m_data);
 }
 
 void NotificationFlowBulkGetSessionEvent::executeCallback(

--- a/meta/NotificationFlowBulkGetSessionEvent.h
+++ b/meta/NotificationFlowBulkGetSessionEvent.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "Notification.h"
+
+namespace sairedis
+{
+    class NotificationFlowBulkGetSessionEvent:
+        public Notification
+    {
+        public:
+
+            NotificationFlowBulkGetSessionEvent(
+                    _In_ const std::string& serializedNotification);
+
+            virtual ~NotificationFlowBulkGetSessionEvent();
+
+        public:
+
+            virtual sai_object_id_t getSwitchId() const override;
+
+            virtual sai_object_id_t getAnyObjectId() const override;
+
+            virtual void processMetadata(
+                    _In_ std::shared_ptr<saimeta::Meta> meta) const override;
+
+            virtual void executeCallback(
+                    _In_ const sai_switch_notifications_t& switchNotifications) const override;
+
+        private:
+
+            sai_object_id_t m_flow_bulk_session_id;
+
+            uint32_t m_count;
+
+            sai_flow_bulk_get_session_event_data_t* m_data;
+    };
+}
+

--- a/meta/SaiSerialize.cpp
+++ b/meta/SaiSerialize.cpp
@@ -2767,7 +2767,7 @@ std::string sai_serialize_flow_bulk_get_session_event_ntf(
 
     if (data == NULL)
     {
-        SWSS_LOG_THROW("data pointer is null");
+        SWSS_LOG_THROW("flow_bulk_get_session_event_data_t pointer is null");
     }
 
     /*
@@ -6322,7 +6322,6 @@ void sai_deserialize_free_flow_bulk_get_session_event_ntf(
         return;
     }
 
-    /* NOTE: No need to free attr as it will not be allocated */
     delete[] data;
 }
 

--- a/meta/sai_serialize.h
+++ b/meta/sai_serialize.h
@@ -356,6 +356,11 @@ std::string sai_serialize_ha_scope_event_ntf(
         _In_ uint32_t count,
         _In_ const sai_ha_scope_event_data_t* ha_scope_event);
 
+std::string sai_serialize_flow_bulk_get_session_event_ntf(
+        _In_ sai_object_id_t flow_bulk_session_id,
+        _In_ uint32_t count,
+        _In_ const sai_flow_bulk_get_session_event_data_t* data);
+
 std::string sai_serialize_port_host_tx_ready_ntf(
         _In_ sai_object_id_t switch_id,
         _In_ sai_object_id_t port_id,
@@ -649,6 +654,12 @@ void sai_deserialize_ha_scope_event_ntf(
         _Out_ uint32_t &count,
         _Out_ sai_ha_scope_event_data_t** ha_scope_event);
 
+void sai_deserialize_flow_bulk_get_session_event_ntf(
+        _In_ const std::string& s,
+        _Out_ sai_object_id_t& flow_bulk_session_id,
+        _Out_ uint32_t& count,
+        _Out_ sai_flow_bulk_get_session_event_data_t** data);
+
 void sai_deserialize_port_host_tx_ready_ntf(
         _In_ const std::string& s,
         _Out_ sai_object_id_t& switch_id,
@@ -711,6 +722,10 @@ void sai_deserialize_ingress_priority_group_attr(
 void sai_deserialize_free_twamp_session_event_ntf(
         _In_ uint32_t count,
         _In_ sai_twamp_session_event_notification_data_t* twamp_session_event);
+
+void sai_deserialize_free_flow_bulk_get_session_event_ntf(
+        _In_ uint32_t count,
+        _In_ sai_flow_bulk_get_session_event_data_t* data);
 
 void sai_deserialize_queue_attr(
         _In_ const std::string& s,

--- a/proxylib/Proxy.cpp
+++ b/proxylib/Proxy.cpp
@@ -66,6 +66,7 @@ Proxy::Proxy(
     m_swNtf.onIcmpEchoSessionStateChange = std::bind(&Proxy::onIcmpEchoSessionStateChange, this, _1, _2);
     m_swNtf.onHaSetEvent = std::bind(&Proxy::onHaSetEvent, this, _1, _2);
     m_swNtf.onHaScopeEvent = std::bind(&Proxy::onHaScopeEvent, this, _1, _2);
+    m_swNtf.onFlowBulkGetSessionEvent = std::bind(&Proxy::onFlowBulkGetSessionEvent, this, _1, _2, _3);
     m_swNtf.onPortHostTxReady = std::bind(&Proxy::onPortHostTxReady, this, _1, _2, _3);
     m_swNtf.onTwampSessionEvent = std::bind(&Proxy::onTwampSessionEvent, this, _1, _2);
     m_swNtf.onTamTelTypeConfigChange = std::bind(&Proxy::onTamTelTypeConfigChange, this, _1);
@@ -1237,6 +1238,18 @@ void Proxy::onHaScopeEvent(
     std::string s = sai_serialize_ha_scope_event_ntf(count, data);
 
     sendNotification(SAI_SWITCH_NOTIFICATION_NAME_HA_SCOPE_EVENT, s);
+}
+
+void Proxy::onFlowBulkGetSessionEvent(
+        _In_ sai_object_id_t flow_bulk_session_id,
+        _In_ uint32_t count,
+        _In_ const sai_flow_bulk_get_session_event_data_t *data)
+{
+    SWSS_LOG_ENTER();
+
+    std::string s = sai_serialize_flow_bulk_get_session_event_ntf(flow_bulk_session_id, count, data);
+
+    sendNotification(SAI_SWITCH_NOTIFICATION_NAME_FLOW_BULK_GET_SESSION_EVENT, s);
 }
 
 void Proxy::onTwampSessionEvent(

--- a/proxylib/Proxy.h
+++ b/proxylib/Proxy.h
@@ -160,6 +160,11 @@ namespace saiproxy
                     _In_ uint32_t count,
                     _In_ const sai_ha_scope_event_data_t *data);
 
+            void onFlowBulkGetSessionEvent(
+                    _In_ sai_object_id_t flow_bulk_session_id,
+                    _In_ uint32_t count,
+                    _In_ const sai_flow_bulk_get_session_event_data_t *data);
+
             void onTwampSessionEvent(
                     _In_ uint32_t count,
                     _In_ const sai_twamp_session_event_notification_data_t *data);

--- a/pyext/pysairedis.cpp
+++ b/pyext/pysairedis.cpp
@@ -98,6 +98,7 @@ PyObject *py_convert_sai_bfd_session_state_notification_t_to_PyObject(const sai_
 PyObject *py_convert_sai_icmp_echo_session_state_notification_t_to_PyObject(const sai_icmp_echo_session_state_notification_t*ntf);
 PyObject *py_convert_sai_ha_set_event_data_t_to_PyObject(const sai_ha_set_event_data_t*ntf);
 PyObject *py_convert_sai_ha_scope_event_data_t_to_PyObject(const sai_ha_scope_event_data_t*ntf);
+PyObject *py_convert_sai_flow_bulk_get_session_event_data_t_to_PyObject(const sai_flow_bulk_get_session_event_data_t*ntf);
 PyObject *py_convert_sai_port_oper_status_notification_t_to_PyObject(const sai_port_oper_status_notification_t*ntf);
 PyObject *py_convert_sai_queue_deadlock_notification_data_t_to_PyObject(const sai_queue_deadlock_notification_data_t*ntf);
 
@@ -110,6 +111,7 @@ static PyObject * py_bfd_session_state_change_notification = NULL;
 static PyObject * py_icmp_echo_session_state_change_notification = NULL;
 static PyObject * py_ha_set_event_notification = NULL;
 static PyObject * py_ha_scope_event_notification = NULL;
+static PyObject * py_flow_bulk_get_session_event_notification = NULL;
 static PyObject * py_tam_tel_type_config_change_notification = NULL;
 
 void call_python(PyObject* callObject, PyObject* arglist)
@@ -257,6 +259,22 @@ static void sai_ha_scope_event_notification(
     Py_DECREF(arglist);
 }
 
+static void sai_flow_bulk_get_session_event_notification(
+        _In_ sai_object_id_t flow_bulk_session_id,
+        _In_ uint32_t count,
+        _In_ const sai_flow_bulk_get_session_event_data_t *data)
+{
+    PyObject* obj = py_convert_sai_flow_bulk_get_session_event_data_t_to_PyObject(data);
+
+    PyObject* arglist = Py_BuildValue("(lIO)", flow_bulk_session_id, count, obj);
+
+    call_python(py_flow_bulk_get_session_event_notification, arglist);
+
+    Py_DECREF(obj);
+
+    Py_DECREF(arglist);
+}
+
 static void sai_tam_tel_type_config_change_notification(
     _In_ sai_object_id_t tam_tel_type_id)
 {
@@ -324,6 +342,11 @@ sai_pointer_t sai_get_notification_pointer(
             Py_XDECREF(py_ha_scope_event_notification);
             py_ha_scope_event_notification = callback;
             return (void*)&sai_ha_scope_event_notification;
+
+        case SAI_SWITCH_ATTR_FLOW_BULK_GET_SESSION_EVENT_NOTIFY:
+            Py_XDECREF(py_flow_bulk_get_session_event_notification);
+            py_flow_bulk_get_session_event_notification = callback;
+            return (void*)&sai_flow_bulk_get_session_event_notification;
 
         case SAI_SWITCH_ATTR_TAM_TEL_TYPE_CONFIG_CHANGE_NOTIFY:
             Py_XDECREF(py_tam_tel_type_config_change_notification);

--- a/pyext/pysairedis.i
+++ b/pyext/pysairedis.i
@@ -76,6 +76,8 @@ sai_ip_prefix_t* sai_ip_prefix_t_from_string(const std::string& s);
 %pointer_functions(sai_ha_set_event_data_t, sai_ha_set_event_data_t_p);
 %array_functions(sai_ha_scope_event_data_t, sai_ha_scope_event_data_t_arr);
 %pointer_functions(sai_ha_scope_event_data_t, sai_ha_scope_event_data_t_p);
+%array_functions(sai_flow_bulk_get_session_event_data_t, sai_flow_bulk_get_session_event_data_t_arr);
+%pointer_functions(sai_flow_bulk_get_session_event_data_t, sai_flow_bulk_get_session_event_data_t_p);
 %array_functions(sai_fdb_event_notification_data_t, sai_fdb_event_notification_data_t_arr);
 %pointer_functions(sai_fdb_event_notification_data_t, sai_fdb_event_notification_data_t_p);
 %array_functions(sai_port_oper_status_notification_t, sai_port_oper_status_notification_t_arr);
@@ -94,6 +96,8 @@ PyObject *py_convert_sai_ha_set_event_data_t_to_PyObject(const sai_ha_set_event_
 { return SWIG_NewPointerObj((void*)ntf, SWIGTYPE_p__sai_ha_set_event_data_t, 0 | 0); }
 PyObject *py_convert_sai_ha_scope_event_data_t_to_PyObject(const sai_ha_scope_event_data_t*ntf)
 { return SWIG_NewPointerObj((void*)ntf, SWIGTYPE_p__sai_ha_scope_event_data_t, 0 | 0); }
+PyObject *py_convert_sai_flow_bulk_get_session_event_data_t_to_PyObject(const sai_flow_bulk_get_session_event_data_t*ntf)
+{ return SWIG_NewPointerObj((void*)ntf, SWIGTYPE_p__sai_flow_bulk_get_session_event_data_t, 0 | 0); }
 PyObject *py_convert_sai_port_oper_status_notification_t_to_PyObject(const sai_port_oper_status_notification_t*ntf)
 { return SWIG_NewPointerObj((void*)ntf, SWIGTYPE_p__sai_port_oper_status_notification_t, 0 | 0); }
 PyObject *py_convert_sai_queue_deadlock_notification_data_t_to_PyObject(const sai_queue_deadlock_notification_data_t*ntf)

--- a/saiasiccmp/Makefile.am
+++ b/saiasiccmp/Makefile.am
@@ -20,6 +20,6 @@ saiasiccmp_CPPFLAGS = $(CODE_COVERAGE_CPPFLAGS)
 saiasiccmp_CXXFLAGS = $(DBGFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS_COMMON) $(CODE_COVERAGE_CXXFLAGS)
 saiasiccmp_LDADD = libAsicCmp.a \
 				   -ldl -lpthread -L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta -lzmq \
-				   $(top_srcdir)/syncd/libSyncd.a $(top_srcdir)/lib/libSaiRedis.a -lhiredis -lswsscommon $(CODE_COVERAGE_LIBS)
+				   $(top_srcdir)/syncd/libSyncd.a $(top_srcdir)/lib/libSaiRedis.a -lhiredis -lswsscommon -lz $(CODE_COVERAGE_LIBS)
 
 TESTS = test.sh

--- a/saidiscovery/Makefile.am
+++ b/saidiscovery/Makefile.am
@@ -13,4 +13,4 @@ saidiscovery_SOURCES = saidiscovery.cpp
 saidiscovery_CPPFLAGS = $(CODE_COVERAGE_CPPFLAGS)
 saidiscovery_CXXFLAGS = $(DBGFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS_COMMON) $(CODE_COVERAGE_CXXFLAGS)
 saidiscovery_LDADD = -lhiredis -lswsscommon $(top_srcdir)/syncd/libSyncd.a $(SAILIB) -lpthread \
-					 -L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta -lzmq $(CODE_COVERAGE_LIBS) $(EXTRA_LIBSAI_LDFLAGS)
+					 -L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta -lzmq -lz $(CODE_COVERAGE_LIBS) $(EXTRA_LIBSAI_LDFLAGS)

--- a/saiplayer/Makefile.am
+++ b/saiplayer/Makefile.am
@@ -16,4 +16,4 @@ saiplayer_SOURCES = saiplayer_main.cpp
 saiplayer_CPPFLAGS = $(CODE_COVERAGE_CPPFLAGS)
 saiplayer_CXXFLAGS = $(DBGFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS_COMMON) $(CODE_COVERAGE_CXXFLAGS)
 saiplayer_LDADD =  libSaiPlayer.a $(top_srcdir)/syncd/libSyncd.a $(top_srcdir)/lib/libSaiRedis.a \
-				   -lhiredis -lswsscommon -lpthread -L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta -lzmq $(CODE_COVERAGE_LIBS)
+				   -lhiredis -lswsscommon -lpthread -L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta -lzmq -lz $(CODE_COVERAGE_LIBS)

--- a/saiplayer/SaiPlayer.cpp
+++ b/saiplayer/SaiPlayer.cpp
@@ -93,6 +93,7 @@ SaiPlayer::SaiPlayer(
     m_sn.onBfdSessionStateChange = std::bind(&SaiPlayer::onBfdSessionStateChange, this, _1, _2);
     m_sn.onHaSetEvent = std::bind(&SaiPlayer::onHaSetEvent, this, _1, _2);
     m_sn.onHaScopeEvent = std::bind(&SaiPlayer::onHaScopeEvent, this, _1, _2);
+    m_sn.onFlowBulkGetSessionEvent = std::bind(&SaiPlayer::onFlowBulkGetSessionEvent, this, _1, _2, _3);
     m_sn.onPortHostTxReady = std::bind(&SaiPlayer::onPortHostTxReady, this, _1, _2, _3);
     m_sn.onIcmpEchoSessionStateChange = std::bind(&SaiPlayer::onIcmpEchoSessionStateChange, this, _1, _2);
     m_switchNotifications= m_sn.getSwitchNotifications();
@@ -200,6 +201,16 @@ void SaiPlayer::onHaSetEvent(
 void SaiPlayer::onHaScopeEvent(
         _In_ uint32_t count,
         _In_ const sai_ha_scope_event_data_t *data)
+{
+    SWSS_LOG_ENTER();
+
+    // empty
+}
+
+void SaiPlayer::onFlowBulkGetSessionEvent(
+        _In_ sai_object_id_t flow_bulk_session_id,
+        _In_ uint32_t count,
+        _In_ const sai_flow_bulk_get_session_event_data_t *data)
 {
     SWSS_LOG_ENTER();
 

--- a/saiplayer/SaiPlayer.h
+++ b/saiplayer/SaiPlayer.h
@@ -279,6 +279,11 @@ namespace saiplayer
                     _In_ uint32_t count,
                     _In_ const sai_ha_scope_event_data_t *data);
 
+            void onFlowBulkGetSessionEvent(
+                    _In_ sai_object_id_t flow_bulk_session_id,
+                    _In_ uint32_t count,
+                    _In_ const sai_flow_bulk_get_session_event_data_t *data);
+
             void onPortHostTxReady(
                     _In_ sai_object_id_t switch_id,
                     _In_ sai_object_id_t port_id,

--- a/syncd/FlowDump.cpp
+++ b/syncd/FlowDump.cpp
@@ -34,11 +34,6 @@ namespace syncd
 
         try
         {
-            // sai_serialize_attr_value already handles all standard types including:
-            // - Enum types (sai_dash_direction_t, sai_dash_flow_action_t, sai_dash_encapsulation_t,
-            //   sai_dash_flow_sync_state_t, sai_ip_addr_family_t) via INT32 with enummetadata
-            // - sai_u8_list_t via UINT8_LIST
-            // - MAC, IP_ADDRESS, IPV4, IPV6, IP_PREFIX, BOOL, CHARDATA, and all numeric types
             return sai_serialize_attr_value(*meta, attr, false);
         }
         catch (const std::exception& e)

--- a/syncd/FlowDump.cpp
+++ b/syncd/FlowDump.cpp
@@ -1,0 +1,388 @@
+#include "FlowDump.h"
+
+#include "meta/sai_serialize.h"
+#include "meta/SaiAttributeList.h"
+
+#include "swss/logger.h"
+
+#include <sstream>
+#include <iomanip>
+#include <algorithm>
+#include <vector>
+#include <exception>
+#include <stdexcept>
+#include <sys/stat.h>
+#include <dirent.h>
+#include <unistd.h>
+#include <errno.h>
+#include <cstring>
+
+namespace syncd
+{
+    constexpr const char* FlowDumpWriter::DEFAULT_BASE_PATH;
+
+    std::string FlowDumpSerializer::serializeAttributeValue(
+            _In_ const sai_attribute_t& attr,
+            _In_ const sai_attr_metadata_t* meta)
+    {
+        SWSS_LOG_ENTER();
+
+        if (meta == nullptr)
+        {
+            return std::string();
+        }
+
+        try
+        {
+            // sai_serialize_attr_value already handles all standard types including:
+            // - Enum types (sai_dash_direction_t, sai_dash_flow_action_t, sai_dash_encapsulation_t,
+            //   sai_dash_flow_sync_state_t, sai_ip_addr_family_t) via INT32 with enummetadata
+            // - sai_u8_list_t via UINT8_LIST
+            // - MAC, IP_ADDRESS, IPV4, IPV6, IP_PREFIX, BOOL, CHARDATA, and all numeric types
+            return sai_serialize_attr_value(*meta, attr, false);
+        }
+        catch (const std::exception& e)
+        {
+            SWSS_LOG_ERROR("Exception in serializeAttributeValue for attr %s: %s",
+                          meta != nullptr ? meta->attridname : "unknown", e.what());
+            return std::string();
+        }
+        catch (...)
+        {
+            SWSS_LOG_ERROR("Unknown exception in serializeAttributeValue for attr %s",
+                          meta != nullptr ? meta->attridname : "unknown");
+            return std::string();
+        }
+    }
+
+    nlohmann::json FlowDumpSerializer::serializeFlowEntryToJson(
+            _In_ const sai_flow_bulk_get_session_event_data_t& event_data)
+    {
+        SWSS_LOG_ENTER();
+
+        nlohmann::json json_line;
+
+        const sai_flow_entry_t& flow_entry = event_data.flow_entry;
+        json_line["em"] = sai_serialize_mac(flow_entry.eni_mac);
+        json_line["vn"] = flow_entry.vnet_id;
+        json_line["pr"] = flow_entry.ip_proto;
+        json_line["si"] = sai_serialize_ip_address(flow_entry.src_ip);
+        json_line["di"] = sai_serialize_ip_address(flow_entry.dst_ip);
+        json_line["sp"] = flow_entry.src_port;
+        json_line["dp"] = flow_entry.dst_port;
+
+        if (event_data.attr != nullptr && event_data.attr_count > 0)
+        {
+            for (uint32_t j = 0; j < event_data.attr_count; ++j)
+            {
+                const sai_attribute_t& attr = event_data.attr[j];
+                auto meta = sai_metadata_get_attr_metadata(static_cast<sai_object_type_t>(SAI_OBJECT_TYPE_FLOW_ENTRY), attr.id);
+                if (meta != nullptr)
+                {
+                    json_line[std::to_string(attr.id)] = FlowDumpSerializer::serializeAttributeValue(attr, meta);
+                }
+            }
+        }
+
+        return json_line;
+    }
+
+    FlowDumpWriter::FlowDumpWriter() :
+        m_base_path(DEFAULT_BASE_PATH)
+    {
+    }
+
+    FlowDumpWriter& FlowDumpWriter::getInstance()
+    {
+        static FlowDumpWriter instance;
+        return instance;
+    }
+
+    FlowDumpWriter::~FlowDumpWriter()
+    {
+        SWSS_LOG_ENTER();
+    }
+
+    std::string FlowDumpWriter::getFilePath(
+            _In_ sai_object_id_t flow_bulk_session_vid) const
+    {
+        SWSS_LOG_ENTER();
+
+        std::ostringstream oss;
+        oss << m_base_path << FLOW_DUMP_FILE_PREFIX
+            << std::hex << std::setfill('0') << std::setw(16) 
+            << flow_bulk_session_vid << FLOW_DUMP_FILE_SUFFIX;
+
+        return oss.str();
+    }
+
+    bool FlowDumpWriter::openFile(
+            _In_ const std::string& file_path,
+            _Out_ gzFile& gz_file)
+    {
+        SWSS_LOG_ENTER();
+
+        // Extract directory path from file path
+        std::string dir_path = file_path;
+        size_t last_slash = dir_path.find_last_of('/');
+        if (last_slash != std::string::npos)
+        {
+            dir_path = dir_path.substr(0, last_slash);
+        }
+        else
+        {
+            dir_path = ".";
+        }
+
+
+        if (!dir_path.empty() && dir_path != ".")
+        {
+            struct stat st;
+            if (stat(dir_path.c_str(), &st) != 0)
+            {
+                SWSS_LOG_ERROR("Failed to write flows. Directory %s does not exist", dir_path.c_str());
+                return false;
+            }
+            else if (!S_ISDIR(st.st_mode))
+            {
+                SWSS_LOG_ERROR("Failed to write flows. Path %s exists but is not a directory", dir_path.c_str());
+                return false;
+            }
+        }
+
+        gz_file = gzopen(file_path.c_str(), "ab");
+        if (gz_file == nullptr)
+        {
+            SWSS_LOG_ERROR("Failed to open file %s for writing", file_path.c_str());
+            return false;
+        }
+
+        SWSS_LOG_DEBUG("Opened flow dump file: %s", file_path.c_str());
+
+        return true;
+    }
+
+    bool FlowDumpWriter::writeData(
+            _In_ gzFile gz_file,
+            _In_ const std::string& data)
+    {
+        SWSS_LOG_ENTER();
+
+        if (gz_file == nullptr)
+        {
+            SWSS_LOG_ERROR("File not open");
+            return false;
+        }
+
+        if (data.empty())
+        {
+            return true;
+        }
+
+        unsigned int len = static_cast<unsigned int>(data.length());
+        int written = gzwrite(gz_file, data.c_str(), len);
+
+        if (written != static_cast<int>(len))
+        {
+            SWSS_LOG_ERROR("Failed to write data to file: wrote %d of %u bytes", written, len);
+            return false;
+        }
+
+        return true;
+    }
+
+    void FlowDumpWriter::flush(
+            _In_ gzFile gz_file)
+    {
+        SWSS_LOG_ENTER();
+
+        if (gz_file != nullptr)
+        {
+            gzflush(gz_file, Z_SYNC_FLUSH);
+        }
+    }
+
+    bool FlowDumpWriter::writeFlowDumpData(
+            _In_ const FlowDumpDataPtr& data,
+            _In_ sai_object_id_t flow_bulk_session_vid)
+    {
+        SWSS_LOG_ENTER();
+
+        if (data == nullptr)
+        {
+            SWSS_LOG_ERROR("FlowDumpData is null");
+            return false;
+        }
+
+        std::string file_path = getFilePath(flow_bulk_session_vid);
+
+        if (!fileExists(file_path))
+        {
+            rotateLogFiles(file_path);
+        }
+
+        std::ostringstream oss;
+        try
+        {
+            for (const auto& json_line : data->json_lines)
+            {
+                oss << json_line.dump() << "\n";
+            }
+        }
+        catch (const std::exception& e)
+        {
+            SWSS_LOG_ERROR("Failed to serialize JSON lines: %s", e.what());
+            return false;
+        }
+
+        gzFile gz_file = nullptr;
+        if (!openFile(file_path, gz_file))
+        {
+            return false;
+        }
+
+        bool success = writeData(gz_file, oss.str());
+        if (!success)
+        {
+            SWSS_LOG_ERROR("Failed to write flow dump data");
+        }
+
+        flush(gz_file);
+        closeFile(gz_file, file_path);
+
+        return success;
+    }
+
+    void FlowDumpWriter::closeFile(
+            _In_ gzFile gz_file,
+            _In_ const std::string& file_path)
+    {
+        SWSS_LOG_ENTER();
+
+        if (gz_file != nullptr)
+        {
+            gzclose(gz_file);
+            SWSS_LOG_DEBUG("Closed flow dump file: %s", file_path.c_str());
+        }
+    }
+
+    const std::string& FlowDumpWriter::getBasePath() const
+    {
+        SWSS_LOG_ENTER();
+
+        return m_base_path;
+    }
+
+    void FlowDumpWriter::setBasePath(
+            _In_ const std::string& base_path)
+    {
+        SWSS_LOG_ENTER();
+
+        m_base_path = base_path;
+        SWSS_LOG_DEBUG("Set flow dump base path to: %s", m_base_path.c_str());
+    }
+
+    bool FlowDumpWriter::fileExists(
+            _In_ const std::string& file_path) const
+    {
+        SWSS_LOG_ENTER();
+
+        struct stat st;
+        if (stat(file_path.c_str(), &st) != 0)
+        {
+            return false;
+        }
+        return S_ISREG(st.st_mode);
+    }
+
+    void FlowDumpWriter::rotateLogFiles(
+            _In_ const std::string& target_file_path)
+    {
+        SWSS_LOG_ENTER();
+
+        std::vector<std::pair<std::string, std::time_t>> files;
+
+        // Check if base directory exists and is a directory
+        struct stat st;
+        if (stat(m_base_path.c_str(), &st) != 0 || !S_ISDIR(st.st_mode))
+        {
+            return;
+        }
+
+        // Extract target filename for comparison
+        size_t last_slash = target_file_path.find_last_of('/');
+        std::string target_filename = (last_slash != std::string::npos) ? 
+                                      target_file_path.substr(last_slash + 1) : 
+                                      target_file_path;
+
+        DIR* dir = opendir(m_base_path.c_str());
+        if (dir == nullptr)
+        {
+            SWSS_LOG_WARN("Failed to open directory %s: %s", m_base_path.c_str(), strerror(errno));
+            return;
+        }
+
+        struct dirent* entry;
+        while ((entry = readdir(dir)) != nullptr)
+        {
+            if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+            {
+                continue;
+            }
+
+            std::string filename = entry->d_name;
+            std::string full_path = m_base_path;
+            if (full_path.back() != '/')
+            {
+                full_path += '/';
+            }
+            full_path += filename;
+
+            // Check if it's a regular file
+            if (stat(full_path.c_str(), &st) != 0 || !S_ISREG(st.st_mode))
+            {
+                continue;
+            }
+
+            // Check if it matches flow dump file pattern
+            if (filename.find(FLOW_DUMP_FILE_PREFIX) == 0 && filename.find(FLOW_DUMP_FILE_SUFFIX) != std::string::npos)
+            {
+                // Skip the target file
+                if (filename == target_filename)
+                {
+                    continue;
+                }
+
+                files.push_back(std::make_pair(full_path, st.st_mtime));
+            }
+        }
+        closedir(dir);
+
+        if (files.size() < MAX_FILES)
+        {
+            return;
+        }
+
+        std::sort(files.begin(), files.end(),
+                  [](const std::pair<std::string, std::time_t>& a,
+                     const std::pair<std::string, std::time_t>& b) {
+                      return a.second < b.second;
+                  });
+
+        size_t files_to_delete = files.size() + 1 - MAX_FILES;
+
+        for (size_t i = 0; i < files_to_delete && i < files.size(); ++i)
+        {
+            const std::string& file_to_delete = files[i].first;
+            if (unlink(file_to_delete.c_str()) == 0)
+            {
+                SWSS_LOG_NOTICE("Deleted oldest flow dump file: %s", file_to_delete.c_str());
+            }
+            else
+            {
+                SWSS_LOG_ERROR("Failed to delete flow dump file %s: %s",
+                               file_to_delete.c_str(), strerror(errno));
+            }
+        }
+    }
+}

--- a/syncd/FlowDump.h
+++ b/syncd/FlowDump.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <nlohmann/json.hpp>
+#include <vector>
+#include <memory>
+#include <string>
+#include <zlib.h>
+
+extern "C" {
+#include "sai.h"
+#include "saimetadata.h"
+}
+
+namespace syncd
+{
+    struct FlowDumpData
+    {
+        std::vector<nlohmann::json> json_lines;
+    };
+
+    using FlowDumpDataPtr = std::shared_ptr<FlowDumpData>;
+
+    namespace FlowDumpSerializer
+    {
+        nlohmann::json serializeFlowEntryToJson(
+           _In_ const sai_flow_bulk_get_session_event_data_t& event_data);
+
+        std::string serializeAttributeValue(
+           _In_ const sai_attribute_t& attr,
+           _In_ const sai_attr_metadata_t* meta);
+    }
+
+    class FlowDumpWriter
+    {
+        public:
+
+            static constexpr const char* DEFAULT_BASE_PATH = "/var/dump/flows/";
+            static constexpr const char* FLOW_DUMP_FILE_PREFIX = "flow_dump_0x";
+            static constexpr const char* FLOW_DUMP_FILE_SUFFIX = ".jsonl.gz";
+            static constexpr size_t MAX_FILES = 2;
+
+            static FlowDumpWriter& getInstance();
+
+            bool writeFlowDumpData(
+                    _In_ const FlowDumpDataPtr& data,
+                    _In_ sai_object_id_t flow_bulk_session_vid);
+
+            const std::string& getBasePath() const;
+
+            void setBasePath(
+                    _In_ const std::string& base_path);
+
+        private:
+
+            FlowDumpWriter();
+            ~FlowDumpWriter();
+
+            FlowDumpWriter(const FlowDumpWriter&) = delete;
+            FlowDumpWriter& operator=(const FlowDumpWriter&) = delete;
+
+            std::string getFilePath(
+                    _In_ sai_object_id_t flow_bulk_session_vid) const;
+
+            bool openFile(
+                    _In_ const std::string& file_path,
+                    _Out_ gzFile& gz_file);
+
+            bool writeData(
+                    _In_ gzFile gz_file,
+                    _In_ const std::string& data);
+
+            void flush(
+                    _In_ gzFile gz_file);
+
+            void closeFile(
+                    _In_ gzFile gz_file,
+                    _In_ const std::string& file_path);
+
+            bool fileExists(
+                    _In_ const std::string& file_path) const;
+
+            void rotateLogFiles(
+                    _In_ const std::string& target_file_path);
+
+        private:
+
+            std::string m_base_path;
+    };
+}

--- a/syncd/Makefile.am
+++ b/syncd/Makefile.am
@@ -27,6 +27,7 @@ libSyncd_a_SOURCES = \
 				DisabledRedisClient.cpp \
 				FlexCounter.cpp \
 				FlexCounterManager.cpp \
+				FlowDump.cpp \
 				GlobalSwitchId.cpp \
 				HardReiniter.cpp \
 				MdioIpcServer.cpp \
@@ -71,7 +72,7 @@ endif
 syncd_CPPFLAGS = $(CODE_COVERAGE_CPPFLAGS)
 syncd_CXXFLAGS = $(DBGFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS_COMMON) $(CODE_COVERAGE_CXXFLAGS) $(CFLAGS_ASAN)
 syncd_LDADD = libSyncd.a $(top_srcdir)/lib/libSaiRedis.a -L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta \
-			  -ldl -lhiredis -lswsscommon $(SAILIB) -lpthread -lzmq $(CODE_COVERAGE_LIBS) $(EXTRA_LIBSAI_LDFLAGS)
+			  -ldl -lhiredis -lswsscommon $(SAILIB) -lpthread -lzmq -lz $(CODE_COVERAGE_LIBS) $(EXTRA_LIBSAI_LDFLAGS)
 syncd_LDFLAGS = $(LDFLAGS_ASAN) -rdynamic
 
 if SAITHRIFT
@@ -117,7 +118,7 @@ syncd_tests_SOURCES = tests.cpp
 syncd_tests_CXXFLAGS = $(DBGFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS_COMMON)
 syncd_tests_LDFLAGS = -Wl,-rpath,$(top_srcdir)/lib/.libs -Wl,-rpath,$(top_srcdir)/meta/.libs
 syncd_tests_LDADD = libSyncd.a -lhiredis -lswsscommon -lpthread -L$(top_srcdir)/lib/.libs -lsairedis \
-			  -L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta -lzmq $(CODE_COVERAGE_LIBS) $(VPP_LIBS)
+			  -L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta -lzmq -lz $(CODE_COVERAGE_LIBS) $(VPP_LIBS)
 
 TESTS = syncd_tests
 
@@ -128,7 +129,7 @@ syncd_dash_SOURCES = $(syncd_SOURCES)
 syncd_dash_CPPFLAGS = $(syncd_CPPFLAGS)
 syncd_dash_CXXFLAGS = $(syncd_CXXFLAGS)
 syncd_dash_LDADD = libSyncd.a $(top_srcdir)/lib/libSaiRedis.a -L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta \
-			  -ldl -lhiredis -lswsscommon -lsai -lprotobuf -lpiprotobuf -lpiprotogrpc -lgrpc++ -lpthread -lzmq $(CODE_COVERAGE_LIBS) $(EXTRA_LIBSAI_LDFLAGS)
+			  -ldl -lhiredis -lswsscommon -lsai -lprotobuf -lpiprotobuf -lpiprotogrpc -lgrpc++ -lpthread -lzmq -lz $(CODE_COVERAGE_LIBS) $(EXTRA_LIBSAI_LDFLAGS)
 syncd_dash_LDFLAGS = $(syncd_LDFLAGS)
 endif
 endif

--- a/syncd/NotificationHandler.h
+++ b/syncd/NotificationHandler.h
@@ -6,6 +6,7 @@ extern "C"{
 
 #include "NotificationQueue.h"
 #include "NotificationProcessor.h"
+#include "FlowDump.h"
 
 #include "swss/table.h"
 
@@ -102,6 +103,11 @@ namespace syncd
                     _In_ uint32_t count,
                     _In_ const sai_ha_scope_event_data_t *data);
 
+            void onFlowBulkGetSessionEvent(
+                    _In_ sai_object_id_t flow_bulk_session_id,
+                    _In_ uint32_t count,
+                    _In_ const sai_flow_bulk_get_session_event_data_t *data);
+
             void onSwitchMacsecPostStatus(
                     _In_ sai_object_id_t switch_id,
                     _In_ sai_switch_macsec_post_status_t switch_macsec_post_status);
@@ -120,6 +126,11 @@ namespace syncd
             void enqueueNotification(
                     _In_ const std::string& op,
                     _In_ const std::string& data);
+
+            void enqueueNotification(
+                    _In_ const std::string& op,
+                    _In_ const std::string& data,
+                    _In_ FlowDumpDataPtr auxiliary_data);
 
         private:
 

--- a/syncd/NotificationProcessor.cpp
+++ b/syncd/NotificationProcessor.cpp
@@ -1121,7 +1121,6 @@ void NotificationProcessor::ntf_process_function()
 
         while (m_notificationQueue->tryDequeue(item))
         {
-            // Process notification with auxiliary data
             processNotification(item);
         }
     }

--- a/syncd/NotificationProcessor.h
+++ b/syncd/NotificationProcessor.h
@@ -4,6 +4,7 @@
 #include "VirtualOidTranslator.h"
 #include "BaseRedisClient.h"
 #include "NotificationProducerBase.h"
+#include "FlowDump.h"
 
 #include "swss/notificationproducer.h"
 
@@ -153,6 +154,10 @@ namespace syncd
             void handle_ha_scope_event(
                     _In_ const std::string &data);
 
+            void handle_flow_bulk_get_session_event(
+                    _In_ const std::string &data,
+                    _In_ FlowDumpDataPtr auxiliary_data = nullptr);
+
             void handle_switch_asic_sdk_health_event(
                     _In_ const std::string &data);
 
@@ -176,6 +181,9 @@ namespace syncd
 
             void processNotification(
                     _In_ const swss::KeyOpFieldsValuesTuple& item);
+
+            void processNotification(
+                    _In_ const NotificationItem& item);
 
         public:
 

--- a/syncd/NotificationQueue.cpp
+++ b/syncd/NotificationQueue.cpp
@@ -18,7 +18,7 @@ NotificationQueue::NotificationQueue(
 {
     SWSS_LOG_ENTER();
 
-    m_queue = std::make_shared<std::queue<swss::KeyOpFieldsValuesTuple>>();
+    m_queue = std::make_shared<std::queue<NotificationItem>>();
 }
 
 NotificationQueue::~NotificationQueue()
@@ -30,6 +30,13 @@ NotificationQueue::~NotificationQueue()
 
 bool NotificationQueue::enqueue(
         _In_ const swss::KeyOpFieldsValuesTuple& item)
+{
+    return enqueue(item, nullptr);
+}
+
+bool NotificationQueue::enqueue(
+        _In_ const swss::KeyOpFieldsValuesTuple& item,
+        _In_ FlowDumpDataPtr auxiliary_data)
 {
     MUTEX;
 
@@ -88,7 +95,7 @@ bool NotificationQueue::enqueue(
 
     if (!candidateToDrop)
     {
-        m_queue->push(item);
+        m_queue->push(NotificationItem(item, auxiliary_data));
 
         return true;
     }
@@ -108,6 +115,18 @@ bool NotificationQueue::enqueue(
 
 bool NotificationQueue::tryDequeue(
         _Out_ swss::KeyOpFieldsValuesTuple& item)
+{
+    NotificationItem ntf_item;
+    if (tryDequeue(ntf_item))
+    {
+        item = ntf_item.notification;
+        return true;
+    }
+    return false;
+}
+
+bool NotificationQueue::tryDequeue(
+        _Out_ NotificationItem& item)
 {
     MUTEX;
 
@@ -143,7 +162,7 @@ bool NotificationQueue::tryDequeue(
          */
         m_queue = nullptr;
 
-        m_queue = std::make_shared<std::queue<swss::KeyOpFieldsValuesTuple>>();
+        m_queue = std::make_shared<std::queue<NotificationItem>>();
     }
 
     return true;

--- a/syncd/NotificationQueue.h
+++ b/syncd/NotificationQueue.h
@@ -6,6 +6,7 @@ extern "C" {
 }
 
 #include "swss/table.h"
+#include "FlowDump.h"
 
 #include <queue>
 #include <mutex>
@@ -31,6 +32,25 @@ extern "C" {
 
 namespace syncd
 {
+    /**
+     * @brief Structure to hold notification data with optional auxiliary data for Flow Dump
+     */
+    struct NotificationItem
+    {
+        swss::KeyOpFieldsValuesTuple notification;
+        FlowDumpDataPtr auxiliary_data;  // Optional auxiliary data (e.g., flow dump JSON lines)
+
+        NotificationItem() = default;
+
+        NotificationItem(
+                _In_ const swss::KeyOpFieldsValuesTuple& ntf,
+                _In_ FlowDumpDataPtr aux = nullptr) :
+            notification(ntf),
+            auxiliary_data(aux)
+        {
+        }
+    };
+
     class NotificationQueue
     {
         public:
@@ -46,8 +66,15 @@ namespace syncd
             bool enqueue(
                     _In_ const swss::KeyOpFieldsValuesTuple& msg);
 
+            bool enqueue(
+                    _In_ const swss::KeyOpFieldsValuesTuple& msg,
+                    _In_ FlowDumpDataPtr auxiliary_data);
+
             bool tryDequeue(
                     _Out_ swss::KeyOpFieldsValuesTuple& msg);
+
+            bool tryDequeue(
+                    _Out_ NotificationItem& item);
 
             size_t getQueueSize();
 
@@ -55,7 +82,7 @@ namespace syncd
 
             std::mutex m_mutex;
 
-            std::shared_ptr<std::queue<swss::KeyOpFieldsValuesTuple>> m_queue;
+            std::shared_ptr<std::queue<NotificationItem>> m_queue;
 
             size_t m_queueSizeLimit;
 

--- a/syncd/SwitchNotifications.cpp
+++ b/syncd/SwitchNotifications.cpp
@@ -119,6 +119,17 @@ void SwitchNotifications::SlotBase::onHaScopeEvent(
     return m_slots.at(context)->m_handler->onHaScopeEvent(count, data);
 }
 
+void SwitchNotifications::SlotBase::onFlowBulkGetSessionEvent(
+        _In_ int context,
+        _In_ sai_object_id_t flow_bulk_session_id,
+        _In_ uint32_t count,
+        _In_ const sai_flow_bulk_get_session_event_data_t *data)
+{
+    SWSS_LOG_ENTER();
+
+    return m_slots.at(context)->m_handler->onFlowBulkGetSessionEvent(flow_bulk_session_id, count, data);
+}
+
 void SwitchNotifications::SlotBase::onQueuePfcDeadlock(
         _In_ int context,
         _In_ uint32_t count,

--- a/syncd/SwitchNotifications.h
+++ b/syncd/SwitchNotifications.h
@@ -105,9 +105,15 @@ namespace syncd
                             _In_ const sai_ha_set_event_data_t *data);
 
                     static void onHaScopeEvent(
+                        _In_ int context,
+                        _In_ uint32_t count,
+                        _In_ const sai_ha_scope_event_data_t *data);
+
+                    static void onFlowBulkGetSessionEvent(
                             _In_ int context,
+                            _In_ sai_object_id_t flow_bulk_session_id,
                             _In_ uint32_t count,
-                            _In_ const sai_ha_scope_event_data_t *data);
+                            _In_ const sai_flow_bulk_get_session_event_data_t *data);
 
                     static void onMacsecPostStatus(
                           _In_ int context,
@@ -165,7 +171,7 @@ namespace syncd
                             .on_switch_ipsec_post_status = &Slot<context>::onSwitchIpsecPostStatus,
                             .on_ha_set_event = &Slot<context>::onHaSetEvent,
                             .on_ha_scope_event = &Slot<context>::onHaScopeEvent,
-                            .on_flow_bulk_get_session_event = nullptr,
+                            .on_flow_bulk_get_session_event = &Slot<context>::onFlowBulkGetSessionEvent,
                             }) { }
 
                 virtual ~Slot() {}
@@ -242,6 +248,16 @@ namespace syncd
                     SWSS_LOG_ENTER();
 
                     return SlotBase::onHaScopeEvent(context, count, data);
+                }
+
+                static void onFlowBulkGetSessionEvent(
+                        _In_ sai_object_id_t flow_bulk_session_id,
+                        _In_ uint32_t count,
+                        _In_ const sai_flow_bulk_get_session_event_data_t *data)
+                {
+                    SWSS_LOG_ENTER();
+
+                    return SlotBase::onFlowBulkGetSessionEvent(context, flow_bulk_session_id, count, data);
                 }
 
                 static void onQueuePfcDeadlock(
@@ -374,6 +390,7 @@ namespace syncd
             std::function<void(sai_object_id_t)>                                                    onTamTelTypeConfigChange;
             std::function<void(uint32_t, const sai_ha_set_event_data_t*)>                          onHaSetEvent;
             std::function<void(uint32_t, const sai_ha_scope_event_data_t*)>                        onHaScopeEvent;
+            std::function<void(sai_object_id_t, uint32_t, const sai_flow_bulk_get_session_event_data_t*)> onFlowBulkGetSessionEvent;
             std::function<void(sai_object_id_t, const sai_macsec_post_status_t)>                   onMacsecPostStatus;
             std::function<void(sai_object_id_t, const sai_ipsec_post_status_t)>                    onIpsecPostStatus;
             std::function<void(sai_object_id_t, const sai_switch_macsec_post_status_t)>            onSwitchMacsecPostStatus;

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -184,6 +184,7 @@ Syncd::Syncd(
     m_sn.onMacsecPostStatus = std::bind(&NotificationHandler::onMacsecPostStatus, m_handler.get(), _1, _2);
     m_sn.onHaSetEvent = std::bind(&NotificationHandler::onHaSetEvent, m_handler.get(), _1, _2);
     m_sn.onHaScopeEvent = std::bind(&NotificationHandler::onHaScopeEvent, m_handler.get(), _1, _2);
+    m_sn.onFlowBulkGetSessionEvent = std::bind(&NotificationHandler::onFlowBulkGetSessionEvent, m_handler.get(), _1, _2, _3);
 
     m_handler->setSwitchNotifications(m_sn.getSwitchNotifications());
 

--- a/syncd/tests/Makefile.am
+++ b/syncd/tests/Makefile.am
@@ -11,6 +11,6 @@ tests_CXXFLAGS = \
 tests_LDADD = \
     $(top_srcdir)/syncd/libSyncd.a $(top_srcdir)/lib/libSaiRedis.a $(top_srcdir)/syncd/libSyncdRequestShutdown.a \
     -L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta -L$(top_srcdir)/vslib/.libs -lsaivs \
-    -lhiredis -lswsscommon -lpthread -lzmq $(LDADD_GTEST) $(CODE_COVERAGE_LIBS) $(VPP_LIBS)
+    -lhiredis -lswsscommon -lpthread -lzmq -lz $(LDADD_GTEST) $(CODE_COVERAGE_LIBS) $(VPP_LIBS)
 
 TESTS = tests

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -9,7 +9,7 @@ vssyncd_CPPFLAGS = $(CODE_COVERAGE_CPPFLAGS)
 vssyncd_CXXFLAGS = $(DBGFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS_COMMON) $(CODE_COVERAGE_CXXFLAGS)
 vssyncd_LDADD = $(top_srcdir)/syncd/libSyncd.a $(top_srcdir)/lib/libSaiRedis.a \
 				-lhiredis -lswsscommon $(SAILIB) -lpthread \
-				-L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta -ldl -lzmq $(CODE_COVERAGE_LIBS)
+				-L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta -ldl -lzmq -lz $(CODE_COVERAGE_LIBS)
 
 if SAITHRIFT
 vssyncd_LDADD += -lrpcserver -lthrift
@@ -19,18 +19,18 @@ tests_SOURCES = tests.cpp
 tests_CXXFLAGS = $(DBGFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS_COMMON)
 tests_LDADD = -lhiredis -lswsscommon -lpthread \
 			  $(top_srcdir)/lib/libsairedis.la $(top_srcdir)/syncd/libSyncd.a \
-			  -L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta -lzmq $(CODE_COVERAGE_LIBS)
+			  -L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta -lzmq -lz $(CODE_COVERAGE_LIBS)
 
 testclient_SOURCES = TestClient.cpp testclient_main.cpp
 testclient_CXXFLAGS = $(DBGFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS_COMMON)
 testclient_LDADD = -lhiredis -lswsscommon -lpthread \
 				   $(top_srcdir)/lib/libsairedis.la $(top_srcdir)/syncd/libSyncd.a \
-				   -L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta -lzmq $(CODE_COVERAGE_LIBS)
+				   -L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta -lzmq -lz $(CODE_COVERAGE_LIBS)
 
 testdash_gtest_SOURCES = TestDashMain.cpp TestDash.cpp TestDashEnv.cpp
 testdash_gtest_CXXFLAGS = $(DBGFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS_COMMON)
 testdash_gtest_LDADD = -lgtest -lhiredis -lswsscommon -lpthread \
 				   $(top_srcdir)/lib/libsairedis.la $(top_srcdir)/syncd/libSyncd.a \
-				   -L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta -lzmq $(CODE_COVERAGE_LIBS)
+				   -L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta -lzmq -lz $(CODE_COVERAGE_LIBS)
 
 TESTS = checksaiapi.sh aspellcheck.pl conflictnames.pl swsslogentercheck.sh checkwhitespace.sh tests BCM56850.pl MLNX2700.pl BCM56971B0.pl NVDAMBF2H536C.pl testdash_gtest

--- a/unittest/meta/Makefile.am
+++ b/unittest/meta/Makefile.am
@@ -29,6 +29,7 @@ tests_SOURCES = \
 				TestNotificationIcmpEchoSessionStateChange.cpp \
 				TestNotificationHaScopeEvent.cpp \
 				TestNotificationHaSetEvent.cpp \
+				TestNotificationFlowBulkGetSessionEvent.cpp \
 				TestNotificationTam.cpp \
                                 TestNotificationMacsecPostStatus.cpp \
                                 TestNotificationSwitchMacsecPostStatus.cpp \

--- a/unittest/meta/TestNotificationFactory.cpp
+++ b/unittest/meta/TestNotificationFactory.cpp
@@ -7,6 +7,7 @@
 #include <nlohmann/json.hpp>
 
 #include <memory>
+#include <cstring>
 
 using namespace sairedis;
 
@@ -128,5 +129,21 @@ TEST(NotificationFactory, deserialize_macsec_post_status)
     auto str = sai_serialize_macsec_post_status_ntf(0x2100000000, SAI_MACSEC_POST_STATUS_PASS);
     auto ntf = NotificationFactory::deserialize(SAI_SWITCH_NOTIFICATION_NAME_MACSEC_POST_STATUS, str);
     EXPECT_EQ(ntf->getNotificationType(), SAI_SWITCH_NOTIFICATION_TYPE_MACSEC_POST_STATUS);
+    EXPECT_EQ(str, ntf->getSerializedNotification());
+}
+
+TEST(NotificationFactory, deserialize_flow_bulk_get_session_event)
+{
+    sai_object_id_t flow_bulk_session_id = 0x123456789abcdef;
+    uint32_t count = 1;
+    sai_flow_bulk_get_session_event_data_t event_data[1];
+    event_data[0].event_type = SAI_FLOW_BULK_GET_SESSION_EVENT_FINISHED;
+    event_data[0].attr_count = 0;
+    event_data[0].attr = nullptr;
+    memset(&event_data[0].flow_entry, 0, sizeof(event_data[0].flow_entry));
+
+    auto str = sai_serialize_flow_bulk_get_session_event_ntf(flow_bulk_session_id, count, event_data);
+    auto ntf = NotificationFactory::deserialize(SAI_SWITCH_NOTIFICATION_NAME_FLOW_BULK_GET_SESSION_EVENT, str);
+    EXPECT_EQ(ntf->getNotificationType(), SAI_SWITCH_NOTIFICATION_TYPE_FLOW_BULK_GET_SESSION_EVENT);
     EXPECT_EQ(str, ntf->getSerializedNotification());
 }

--- a/unittest/meta/TestNotificationFlowBulkGetSessionEvent.cpp
+++ b/unittest/meta/TestNotificationFlowBulkGetSessionEvent.cpp
@@ -1,0 +1,82 @@
+#include "NotificationFlowBulkGetSessionEvent.h"
+#include "Meta.h"
+#include "MetaTestSaiInterface.h"
+
+#include "sairediscommon.h"
+#include "sai_serialize.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+using namespace sairedis;
+using namespace saimeta;
+
+static std::string s = "{\"bulk_session_id\":\"oid:0x123456789abcdef\",\"data\":[{\"event_type\":\"SAI_FLOW_BULK_GET_SESSION_EVENT_FINISHED\"}]}";
+static std::string null = "{\"bulk_session_id\":\"oid:0x0\",\"data\":[{\"event_type\":\"SAI_FLOW_BULK_GET_SESSION_EVENT_FINISHED\"}]}";
+static std::string emptydata = "{\"bulk_session_id\":\"oid:0x123456789abcdef\",\"data\":[]}";
+
+TEST(NotificationFlowBulkGetSessionEvent, ctr)
+{
+    NotificationFlowBulkGetSessionEvent n(s);
+}
+
+TEST(NotificationFlowBulkGetSessionEvent, getSwitchId)
+{
+    NotificationFlowBulkGetSessionEvent n(s);
+
+    EXPECT_EQ(n.getSwitchId(), SAI_NULL_OBJECT_ID);
+
+    NotificationFlowBulkGetSessionEvent n2(null);
+
+    EXPECT_EQ(n2.getSwitchId(), SAI_NULL_OBJECT_ID);
+
+    NotificationFlowBulkGetSessionEvent n3(emptydata);
+
+    EXPECT_EQ(n3.getSwitchId(), SAI_NULL_OBJECT_ID);
+}
+
+TEST(NotificationFlowBulkGetSessionEvent, getAnyObjectId)
+{
+    NotificationFlowBulkGetSessionEvent n(s);
+
+    EXPECT_EQ(n.getAnyObjectId(), 0x123456789abcdef);
+
+    NotificationFlowBulkGetSessionEvent n2(null);
+
+    EXPECT_EQ(n2.getAnyObjectId(), SAI_NULL_OBJECT_ID);
+
+    NotificationFlowBulkGetSessionEvent n3(emptydata);
+
+    EXPECT_EQ(n3.getAnyObjectId(), 0x123456789abcdef);
+}
+
+TEST(NotificationFlowBulkGetSessionEvent, processMetadata)
+{
+    NotificationFlowBulkGetSessionEvent n(s);
+
+    auto sai = std::make_shared<MetaTestSaiInterface>();
+    auto meta = std::make_shared<Meta>(sai);
+
+    n.processMetadata(meta);
+}
+
+static void on_flow_bulk_get_session_event(
+        _In_ sai_object_id_t flow_bulk_session_id,
+        _In_ uint32_t count,
+        _In_ const sai_flow_bulk_get_session_event_data_t* data)
+{
+    SWSS_LOG_ENTER();
+}
+
+TEST(NotificationFlowBulkGetSessionEvent, executeCallback)
+{
+    NotificationFlowBulkGetSessionEvent n(s);
+
+    sai_switch_notifications_t switchNotifications;
+    switchNotifications.on_flow_bulk_get_session_event = &on_flow_bulk_get_session_event;
+
+    n.executeCallback(switchNotifications);
+}
+
+

--- a/unittest/meta/TestSaiSerialize.cpp
+++ b/unittest/meta/TestSaiSerialize.cpp
@@ -1635,3 +1635,143 @@ TEST(SaiSerialize, serialize_stat_st_capability_list)
     EXPECT_EQ(stats_capability.list[1].minimal_polling_interval, 200);
 }
 
+TEST(SaiSerialize, sai_serialize_flow_bulk_get_session_event_ntf_null_data)
+{
+    SWSS_LOG_ENTER();
+
+    EXPECT_THROW(sai_serialize_flow_bulk_get_session_event_ntf(0x123456789abcdef, 1, nullptr), std::runtime_error);
+}
+
+TEST(SaiSerialize, sai_serialize_deserialize_flow_bulk_get_session_event_ntf_single_finished)
+{
+    SWSS_LOG_ENTER();
+
+    sai_object_id_t flow_bulk_session_id = 0x123456789abcdef;
+    uint32_t count = 1;
+    sai_flow_bulk_get_session_event_data_t event_data[1];
+    
+    memset(&event_data[0], 0, sizeof(event_data[0]));
+    event_data[0].event_type = SAI_FLOW_BULK_GET_SESSION_EVENT_FINISHED;
+    event_data[0].attr_count = 0;
+    event_data[0].attr = nullptr;
+
+    std::string serialized = sai_serialize_flow_bulk_get_session_event_ntf(flow_bulk_session_id, count, event_data);
+
+    sai_object_id_t deserialized_session_id;
+    uint32_t deserialized_count;
+    sai_flow_bulk_get_session_event_data_t* deserialized_data;
+
+    sai_deserialize_flow_bulk_get_session_event_ntf(serialized, deserialized_session_id, deserialized_count, &deserialized_data);
+
+    EXPECT_EQ(deserialized_session_id, flow_bulk_session_id);
+    EXPECT_EQ(deserialized_count, count);
+    EXPECT_EQ(deserialized_data[0].event_type, SAI_FLOW_BULK_GET_SESSION_EVENT_FINISHED);
+    EXPECT_EQ(deserialized_data[0].attr_count, 0);
+    EXPECT_EQ(deserialized_data[0].attr, nullptr);
+
+    sai_deserialize_free_flow_bulk_get_session_event_ntf(deserialized_count, deserialized_data);
+}
+
+TEST(SaiSerialize, sai_serialize_deserialize_flow_bulk_get_session_event_ntf_multiple_events)
+{
+    SWSS_LOG_ENTER();
+
+    sai_object_id_t flow_bulk_session_id = 0xabcdef1234567890;
+    uint32_t count = 3;
+    sai_flow_bulk_get_session_event_data_t event_data[3];
+    
+    memset(event_data, 0, sizeof(event_data));
+    
+    event_data[0].event_type = SAI_FLOW_BULK_GET_SESSION_EVENT_FLOW_ENTRY;
+    event_data[0].attr_count = 0;
+    event_data[0].attr = nullptr;
+    
+    event_data[1].event_type = SAI_FLOW_BULK_GET_SESSION_EVENT_FINISHED;
+    event_data[1].attr_count = 0;
+    event_data[1].attr = nullptr;
+    
+    event_data[2].event_type = SAI_FLOW_BULK_GET_SESSION_EVENT_FLOW_ENTRY;
+    event_data[2].attr_count = 0;
+    event_data[2].attr = nullptr;
+
+    std::string serialized = sai_serialize_flow_bulk_get_session_event_ntf(flow_bulk_session_id, count, event_data);
+
+    sai_object_id_t deserialized_session_id;
+    uint32_t deserialized_count;
+    sai_flow_bulk_get_session_event_data_t* deserialized_data;
+
+    sai_deserialize_flow_bulk_get_session_event_ntf(serialized, deserialized_session_id, deserialized_count, &deserialized_data);
+
+    EXPECT_EQ(deserialized_session_id, flow_bulk_session_id);
+    EXPECT_EQ(deserialized_count, count);
+    
+    EXPECT_EQ(deserialized_data[0].event_type, SAI_FLOW_BULK_GET_SESSION_EVENT_FLOW_ENTRY);
+    EXPECT_EQ(deserialized_data[0].attr_count, 0);
+    EXPECT_EQ(deserialized_data[0].attr, nullptr);
+    
+    EXPECT_EQ(deserialized_data[1].event_type, SAI_FLOW_BULK_GET_SESSION_EVENT_FINISHED);
+    EXPECT_EQ(deserialized_data[1].attr_count, 0);
+    EXPECT_EQ(deserialized_data[1].attr, nullptr);
+    
+    EXPECT_EQ(deserialized_data[2].event_type, SAI_FLOW_BULK_GET_SESSION_EVENT_FLOW_ENTRY);
+    EXPECT_EQ(deserialized_data[2].attr_count, 0);
+    EXPECT_EQ(deserialized_data[2].attr, nullptr);
+
+    sai_deserialize_free_flow_bulk_get_session_event_ntf(deserialized_count, deserialized_data);
+}
+
+TEST(SaiSerialize, sai_serialize_deserialize_flow_bulk_get_session_event_ntf_empty_array)
+{
+    SWSS_LOG_ENTER();
+
+    sai_object_id_t flow_bulk_session_id = 0x9876543210fedcba;
+    uint32_t count = 0;
+    sai_flow_bulk_get_session_event_data_t event_data[1];
+    
+    memset(&event_data[0], 0, sizeof(event_data[0]));
+    event_data[0].event_type = SAI_FLOW_BULK_GET_SESSION_EVENT_FINISHED;
+    event_data[0].attr_count = 0;
+    event_data[0].attr = nullptr;
+
+    std::string serialized = sai_serialize_flow_bulk_get_session_event_ntf(flow_bulk_session_id, count, event_data);
+
+    sai_object_id_t deserialized_session_id;
+    uint32_t deserialized_count;
+    sai_flow_bulk_get_session_event_data_t* deserialized_data;
+
+    sai_deserialize_flow_bulk_get_session_event_ntf(serialized, deserialized_session_id, deserialized_count, &deserialized_data);
+
+    EXPECT_EQ(deserialized_session_id, flow_bulk_session_id);
+    EXPECT_EQ(deserialized_count, 0);
+
+    sai_deserialize_free_flow_bulk_get_session_event_ntf(deserialized_count, deserialized_data);
+}
+
+TEST(SaiSerialize, sai_serialize_deserialize_flow_bulk_get_session_event_ntf_null_session_id)
+{
+    SWSS_LOG_ENTER();
+
+    sai_object_id_t flow_bulk_session_id = SAI_NULL_OBJECT_ID;
+    uint32_t count = 1;
+    sai_flow_bulk_get_session_event_data_t event_data[1];
+    
+    memset(&event_data[0], 0, sizeof(event_data[0]));
+    event_data[0].event_type = SAI_FLOW_BULK_GET_SESSION_EVENT_FINISHED;
+    event_data[0].attr_count = 0;
+    event_data[0].attr = nullptr;
+
+    std::string serialized = sai_serialize_flow_bulk_get_session_event_ntf(flow_bulk_session_id, count, event_data);
+
+    sai_object_id_t deserialized_session_id;
+    uint32_t deserialized_count;
+    sai_flow_bulk_get_session_event_data_t* deserialized_data;
+
+    sai_deserialize_flow_bulk_get_session_event_ntf(serialized, deserialized_session_id, deserialized_count, &deserialized_data);
+
+    EXPECT_EQ(deserialized_session_id, SAI_NULL_OBJECT_ID);
+    EXPECT_EQ(deserialized_count, count);
+    EXPECT_EQ(deserialized_data[0].event_type, SAI_FLOW_BULK_GET_SESSION_EVENT_FINISHED);
+
+    sai_deserialize_free_flow_bulk_get_session_event_ntf(deserialized_count, deserialized_data);
+}
+

--- a/unittest/proxylib/Makefile.am
+++ b/unittest/proxylib/Makefile.am
@@ -15,6 +15,6 @@ tests_LDADD = $(LDADD_GTEST) $(top_srcdir)/proxylib/libSaiProxy.a \
 			  $(top_srcdir)/syncd/libSyncd.a \
 			  -lhiredis -lswsscommon -lpthread \
 			  -L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta \
-			  -lzmq $(CODE_COVERAGE_LIBS)
+			  -lzmq -lz $(CODE_COVERAGE_LIBS)
 
 TESTS = tests

--- a/unittest/proxylib/TestProxy.cpp
+++ b/unittest/proxylib/TestProxy.cpp
@@ -174,6 +174,18 @@ static void onHaScopeEvent(
     ntfCounter++;
 }
 
+static void onFlowBulkGetSessionEvent(
+        _In_ sai_object_id_t flow_bulk_session_id,
+        _In_ uint32_t count,
+        _In_ const sai_flow_bulk_get_session_event_data_t *data)
+{
+    SWSS_LOG_ENTER();
+
+    SWSS_LOG_NOTICE("received: onFlowBulkGetSessionEvent");
+
+    ntfCounter++;
+}
+
 static void onBfdSessionStateChange(
         _In_ uint32_t count,
         _In_ const sai_bfd_session_state_notification_t *data)
@@ -300,6 +312,10 @@ TEST(Proxy, notifications)
 
     attr.id = SAI_SWITCH_ATTR_HA_SCOPE_EVENT_NOTIFY;
     attr.value.ptr = (void*)&onHaScopeEvent;
+    sai.set(SAI_OBJECT_TYPE_SWITCH, switch_id, &attr);
+
+    attr.id = SAI_SWITCH_ATTR_FLOW_BULK_GET_SESSION_EVENT_NOTIFY;
+    attr.value.ptr = (void*)&onFlowBulkGetSessionEvent;
     sai.set(SAI_OBJECT_TYPE_SWITCH, switch_id, &attr);
 
     attr.id = SAI_SWITCH_ATTR_BFD_SESSION_STATE_CHANGE_NOTIFY;

--- a/unittest/syncd/Makefile.am
+++ b/unittest/syncd/Makefile.am
@@ -22,11 +22,12 @@ tests_SOURCES = main.cpp \
 				TestPortStateChangeHandler.cpp \
 				TestWorkaround.cpp \
 				TestSyncd.cpp \
-				TestVendorSai.cpp
+				TestVendorSai.cpp \
+				TestFlowDump.cpp
 
 tests_CXXFLAGS = $(DBGFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS_COMMON)
 tests_LDFLAGS = -Wl,-rpath,$(top_srcdir)/lib/.libs -Wl,-rpath,$(top_srcdir)/meta/.libs
 tests_LDADD = $(LDADD_GTEST) $(top_srcdir)/syncd/libSyncdRequestShutdown.a $(top_srcdir)/syncd/libSyncd.a $(top_srcdir)/vslib/libSaiVS.a $(top_srcdir)/syncd/libMdioIpcClient.a \
-			  -lhiredis -lswsscommon -lnl-genl-3 -lnl-nf-3 -lnl-route-3 -lnl-3 -lpthread -L$(top_srcdir)/lib/.libs -lsairedis -L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta -lzmq $(CODE_COVERAGE_LIBS) $(VPP_LIBS)
+			  -lhiredis -lswsscommon -lnl-genl-3 -lnl-nf-3 -lnl-route-3 -lnl-3 -lpthread -L$(top_srcdir)/lib/.libs -lsairedis -L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta -lzmq -lz $(CODE_COVERAGE_LIBS) $(VPP_LIBS)
 
 TESTS = tests

--- a/unittest/syncd/TestFlowDump.cpp
+++ b/unittest/syncd/TestFlowDump.cpp
@@ -1,0 +1,1010 @@
+#include "FlowDump.h"
+#include "meta/sai_serialize.h"
+
+#include <gtest/gtest.h>
+#include <cstring>
+#include <fstream>
+#include <sstream>
+#include <zlib.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <dirent.h>
+#include <errno.h>
+#include <arpa/inet.h>
+#include <thread>
+#include <chrono>
+#include <algorithm>
+
+using namespace syncd;
+
+class FlowDumpTest : public ::testing::Test
+{
+    protected:
+
+        virtual void SetUp()
+        {
+            // Reset FlowDumpWriter base path to default for each test
+            FlowDumpWriter& writer = FlowDumpWriter::getInstance();
+            writer.setBasePath(FlowDumpWriter::DEFAULT_BASE_PATH);
+
+            // Set up test data
+            memset(&m_flow_entry, 0, sizeof(m_flow_entry));
+            memset(&m_event_data, 0, sizeof(m_event_data));
+
+            // Set up a test flow entry
+            m_flow_entry.vnet_id = 1; // uint16_t, so use small values
+            m_flow_entry.ip_proto = 6; // TCP
+            m_flow_entry.src_port = 12345;
+            m_flow_entry.dst_port = 80;
+
+            // Set up MAC address
+            uint8_t eni_mac[6] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55};
+            memcpy(m_flow_entry.eni_mac, eni_mac, 6);
+
+            // Set up source IP (IPv4) - use network byte order
+            m_flow_entry.src_ip.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
+            in_addr_t src_ip = inet_addr("10.10.10.10");
+            m_flow_entry.src_ip.addr.ip4 = src_ip;
+
+            // Set up destination IP (IPv4) - use network byte order
+            m_flow_entry.dst_ip.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
+            in_addr_t dst_ip = inet_addr("192.168.0.1");
+            m_flow_entry.dst_ip.addr.ip4 = dst_ip;
+
+            // Set up event data
+            m_event_data.event_type = SAI_FLOW_BULK_GET_SESSION_EVENT_FLOW_ENTRY;
+            m_event_data.flow_entry = m_flow_entry;
+            m_event_data.attr_count = 0;
+            m_event_data.attr = nullptr;
+        }
+
+        virtual void TearDown()
+        {
+            // Clean up test files
+            removeTestDirectory(m_test_dir);
+        }
+
+        void removeTestDirectory(const std::string& dir_path)
+        {
+            DIR* dir = opendir(dir_path.c_str());
+            if (dir != nullptr)
+            {
+                struct dirent* entry;
+                while ((entry = readdir(dir)) != nullptr)
+                {
+                    if (strcmp(entry->d_name, ".") != 0 && strcmp(entry->d_name, "..") != 0)
+                    {
+                        std::string file_path = dir_path + "/" + entry->d_name;
+                        unlink(file_path.c_str());
+                    }
+                }
+                closedir(dir);
+                rmdir(dir_path.c_str());
+            }
+        }
+
+        void clearTestDirectory(const std::string& dir_path)
+        {
+            // Clear any existing files in the directory
+            DIR* dir = opendir(dir_path.c_str());
+            if (dir != nullptr)
+            {
+                struct dirent* entry;
+                while ((entry = readdir(dir)) != nullptr)
+                {
+                    if (strcmp(entry->d_name, ".") != 0 && strcmp(entry->d_name, "..") != 0)
+                    {
+                        std::string file_path = dir_path + "/" + entry->d_name;
+                        unlink(file_path.c_str());
+                    }
+                }
+                closedir(dir);
+            }
+            else
+            {
+                // Directory doesn't exist, create it
+                mkdir(dir_path.c_str(), 0755);
+            }
+        }
+
+        sai_flow_entry_t m_flow_entry;
+        sai_flow_bulk_get_session_event_data_t m_event_data;
+        std::string m_test_dir = "/tmp/test_flow_dump";
+};
+
+// Test FlowDumpSerializer with a single flow entry
+TEST_F(FlowDumpTest, FlowDumpSerializer_SingleFlowEntry)
+{
+    nlohmann::json json_line = FlowDumpSerializer::serializeFlowEntryToJson(m_event_data);
+
+    // Verify flow entry fields are serialized correctly
+    EXPECT_EQ(json_line["vn"], 1);
+    EXPECT_EQ(json_line["pr"], 6);
+    EXPECT_EQ(json_line["sp"], 12345);
+    EXPECT_EQ(json_line["dp"], 80);
+    EXPECT_EQ(json_line["em"], "00:11:22:33:44:55");
+    EXPECT_EQ(json_line["si"], "10.10.10.10");
+    EXPECT_EQ(json_line["di"], "192.168.0.1");
+}
+
+// Test FlowDumpSerializer with multiple flow entries
+TEST_F(FlowDumpTest, FlowDumpSerializer_MultipleFlowEntries)
+{
+    // First flow entry
+    sai_flow_bulk_get_session_event_data_t event_data1 = m_event_data;
+
+    // Second flow entry with different values
+    sai_flow_bulk_get_session_event_data_t event_data2 = m_event_data;
+    event_data2.flow_entry.vnet_id = 2; // uint16_t, so use small values
+    event_data2.flow_entry.src_port = 54321;
+    event_data2.flow_entry.dst_port = 443;
+
+    nlohmann::json json_line1 = FlowDumpSerializer::serializeFlowEntryToJson(event_data1);
+    nlohmann::json json_line2 = FlowDumpSerializer::serializeFlowEntryToJson(event_data2);
+
+    // Verify first entry
+    EXPECT_EQ(json_line1["vn"], 1);
+    EXPECT_EQ(json_line1["sp"], 12345);
+
+    // Verify second entry
+    EXPECT_EQ(json_line2["vn"], 2);
+    EXPECT_EQ(json_line2["sp"], 54321);
+    EXPECT_EQ(json_line2["dp"], 443);
+}
+
+// Test FlowDumpSerializer with FINISHED event (should still serialize, event_type is not checked)
+TEST_F(FlowDumpTest, FlowDumpSerializer_FinishedEvent)
+{
+    sai_flow_bulk_get_session_event_data_t event_data = m_event_data;
+    event_data.event_type = SAI_FLOW_BULK_GET_SESSION_EVENT_FINISHED;
+
+    // serializeFlowEntryToJson doesn't check event_type, it just serializes the flow_entry
+    nlohmann::json json_line = FlowDumpSerializer::serializeFlowEntryToJson(event_data);
+
+    // Should still serialize the flow entry data
+    EXPECT_EQ(json_line["vn"], 1);
+    EXPECT_EQ(json_line["sp"], 12345);
+}
+
+// Test FlowDumpSerializer with flow attributes
+TEST_F(FlowDumpTest, FlowDumpSerializer_WithAttributes)
+{
+    sai_flow_bulk_get_session_event_data_t event_data = m_event_data;
+
+    // Set up attributes
+    sai_attribute_t attrs[4];
+    memset(attrs, 0, sizeof(attrs));
+
+    // Attribute 1: Version (uint32)
+    attrs[0].id = SAI_FLOW_ENTRY_ATTR_VERSION;
+    attrs[0].value.u32 = 12345;
+
+    // Attribute 2: Is unidirectional flow (bool)
+    attrs[1].id = SAI_FLOW_ENTRY_ATTR_IS_UNIDIRECTIONAL_FLOW;
+    attrs[1].value.booldata = true;
+
+    // Attribute 3: Destination MAC
+    attrs[2].id = SAI_FLOW_ENTRY_ATTR_DST_MAC;
+    uint8_t dst_mac[6] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+    memcpy(attrs[2].value.mac, dst_mac, 6);
+
+    // Attribute 4: Source IP (sai_ip_address_t)
+    attrs[3].id = SAI_FLOW_ENTRY_ATTR_SIP;
+    attrs[3].value.ipaddr.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
+    attrs[3].value.ipaddr.addr.ip4 = inet_addr("172.16.0.1");
+
+    event_data.attr_count = 4;
+    event_data.attr = attrs;
+
+    nlohmann::json json_line = FlowDumpSerializer::serializeFlowEntryToJson(event_data);
+
+    // Verify flow entry fields are serialized correctly
+    EXPECT_EQ(json_line["vn"], 1);
+    EXPECT_EQ(json_line["pr"], 6);
+    EXPECT_EQ(json_line["sp"], 12345);
+    EXPECT_EQ(json_line["dp"], 80);
+    EXPECT_EQ(json_line["em"], "00:11:22:33:44:55");
+    EXPECT_EQ(json_line["si"], "10.10.10.10");
+    EXPECT_EQ(json_line["di"], "192.168.0.1");
+
+    // Verify attributes are serialized correctly (using attribute ID as key)
+    // Note: serializeAttributeValue returns strings for all types
+    std::string attr_version_key = std::to_string(SAI_FLOW_ENTRY_ATTR_VERSION);
+    std::string attr_unidirectional_key = std::to_string(SAI_FLOW_ENTRY_ATTR_IS_UNIDIRECTIONAL_FLOW);
+    std::string attr_dst_mac_key = std::to_string(SAI_FLOW_ENTRY_ATTR_DST_MAC);
+    std::string attr_sip_key = std::to_string(SAI_FLOW_ENTRY_ATTR_SIP);
+
+    ASSERT_TRUE(json_line.contains(attr_version_key));
+    EXPECT_EQ(json_line[attr_version_key], "12345");  // Serialized as string
+
+    ASSERT_TRUE(json_line.contains(attr_unidirectional_key));
+    EXPECT_EQ(json_line[attr_unidirectional_key], "true");  // Serialized as string
+
+    ASSERT_TRUE(json_line.contains(attr_dst_mac_key));
+    EXPECT_EQ(json_line[attr_dst_mac_key], "AA:BB:CC:DD:EE:FF");
+
+    ASSERT_TRUE(json_line.contains(attr_sip_key));
+    EXPECT_EQ(json_line[attr_sip_key], "172.16.0.1");
+}
+
+// Test FlowDumpWriter - write and read back flow dump data
+TEST_F(FlowDumpTest, FlowDumpWriter_WriteAndRead)
+{
+    // Clear any existing files in test directory
+    clearTestDirectory(m_test_dir);
+
+    // Set base path to test directory
+    FlowDumpWriter& writer = FlowDumpWriter::getInstance();
+    writer.setBasePath(m_test_dir + "/");
+
+    // Create flow dump data
+    FlowDumpDataPtr data = std::make_shared<FlowDumpData>();
+    nlohmann::json json_line1;
+    json_line1["em"] = "00:11:22:33:44:55";
+    json_line1["vn"] = 1;
+    json_line1["pr"] = 6;
+    json_line1["si"] = "10.10.10.10";
+    json_line1["di"] = "192.168.0.1";
+    json_line1["sp"] = 12345;
+    json_line1["dp"] = 80;
+
+    nlohmann::json json_line2;
+    json_line2["em"] = "AA:BB:CC:DD:EE:FF";
+    json_line2["vn"] = 2;
+    json_line2["pr"] = 17; // UDP
+    json_line2["si"] = "192.168.1.1";
+    json_line2["di"] = "10.0.0.1";
+    json_line2["sp"] = 54321;
+    json_line2["dp"] = 53;
+
+    data->json_lines.push_back(json_line1);
+    data->json_lines.push_back(json_line2);
+
+    // Write flow dump data
+    sai_object_id_t test_vid = 0x2000000000001;
+    bool success = writer.writeFlowDumpData(data, test_vid);
+    ASSERT_TRUE(success);
+
+    // Verify file was created - find the actual file that was created
+    std::string expected_file;
+    DIR* dir = opendir(m_test_dir.c_str());
+    ASSERT_NE(dir, nullptr);
+    struct dirent* entry;
+    bool found = false;
+    while ((entry = readdir(dir)) != nullptr)
+    {
+        if (strncmp(entry->d_name, "flow_dump_", 10) == 0)
+        {
+            expected_file = m_test_dir + "/" + entry->d_name;
+            found = true;
+            break;
+        }
+    }
+    closedir(dir);
+    ASSERT_TRUE(found) << "No flow dump file found in " << m_test_dir;
+
+    // Verify file exists and is readable
+    struct stat file_stat;
+    ASSERT_EQ(stat(expected_file.c_str(), &file_stat), 0);
+
+    // Read and decompress the file
+    gzFile gz_file = gzopen(expected_file.c_str(), "rb");
+    ASSERT_NE(gz_file, nullptr);
+
+    char buffer[4096];
+    std::string decompressed_data;
+    int bytes_read;
+    while ((bytes_read = gzread(gz_file, buffer, sizeof(buffer) - 1)) > 0)
+    {
+        buffer[bytes_read] = '\0';
+        decompressed_data += buffer;
+    }
+    gzclose(gz_file);
+
+    // Parse the decompressed data
+    std::istringstream iss(decompressed_data);
+    std::string line;
+    std::vector<nlohmann::json> read_lines;
+
+    while (std::getline(iss, line))
+    {
+        if (!line.empty())
+        {
+            read_lines.push_back(nlohmann::json::parse(line));
+        }
+    }
+
+    // Verify we read back 2 lines
+    ASSERT_EQ(read_lines.size(), 2);
+
+    // Verify first line
+    EXPECT_EQ(read_lines[0]["em"], "00:11:22:33:44:55");
+    EXPECT_EQ(read_lines[0]["vn"], 1);
+    EXPECT_EQ(read_lines[0]["pr"], 6);
+    EXPECT_EQ(read_lines[0]["si"], "10.10.10.10");
+    EXPECT_EQ(read_lines[0]["di"], "192.168.0.1");
+    EXPECT_EQ(read_lines[0]["sp"], 12345);
+    EXPECT_EQ(read_lines[0]["dp"], 80);
+
+    // Verify second line
+    EXPECT_EQ(read_lines[1]["em"], "AA:BB:CC:DD:EE:FF");
+    EXPECT_EQ(read_lines[1]["vn"], 2);
+    EXPECT_EQ(read_lines[1]["pr"], 17);
+    EXPECT_EQ(read_lines[1]["si"], "192.168.1.1");
+    EXPECT_EQ(read_lines[1]["di"], "10.0.0.1");
+    EXPECT_EQ(read_lines[1]["sp"], 54321);
+    EXPECT_EQ(read_lines[1]["dp"], 53);
+}
+
+// Test FlowDumpWriter - verify file path generation
+TEST_F(FlowDumpTest, FlowDumpWriter_FilePathGeneration)
+{
+    std::string test_dir = "/tmp/test";
+    
+    // Clear any existing files in test directory
+    clearTestDirectory(test_dir);
+
+    FlowDumpWriter& writer = FlowDumpWriter::getInstance();
+    writer.setBasePath(test_dir + "/");
+
+    sai_object_id_t test_vid = 0x3000000000001;
+    FlowDumpDataPtr data = std::make_shared<FlowDumpData>();
+    nlohmann::json json_line;
+    json_line["em"] = "00:11:22:33:44:55";
+    data->json_lines.push_back(json_line);
+
+    bool success = writer.writeFlowDumpData(data, test_vid);
+    ASSERT_TRUE(success);
+
+    // Verify file was created - find the actual file that was created
+    std::string expected_file;
+    DIR* dir = opendir("/tmp/test");
+    ASSERT_NE(dir, nullptr);
+    struct dirent* entry;
+    bool found = false;
+    while ((entry = readdir(dir)) != nullptr)
+    {
+        if (strncmp(entry->d_name, "flow_dump_", 10) == 0)
+        {
+            expected_file = test_dir + "/" + std::string(entry->d_name);
+            found = true;
+            break;
+        }
+    }
+    closedir(dir);
+    ASSERT_TRUE(found) << "No flow dump file found in " << test_dir;
+
+    // Verify file exists
+    struct stat file_stat;
+    ASSERT_EQ(stat(expected_file.c_str(), &file_stat), 0);
+
+    // Clean up
+    unlink(expected_file.c_str());
+    rmdir(test_dir.c_str());
+
+    // Clean up
+    unlink(expected_file.c_str());
+    rmdir(test_dir.c_str());
+}
+
+// Test FlowDumpWriter - verify base path getter/setter
+TEST_F(FlowDumpTest, FlowDumpWriter_BasePathGetterSetter)
+{
+    FlowDumpWriter& writer = FlowDumpWriter::getInstance();
+
+    // Test default path
+    const std::string& default_path = writer.getBasePath();
+    EXPECT_EQ(default_path, FlowDumpWriter::DEFAULT_BASE_PATH);
+
+    // Set new path
+    std::string new_path = "/tmp/custom/path/";
+    writer.setBasePath(new_path);
+
+    // Verify new path
+    const std::string& retrieved_path = writer.getBasePath();
+    EXPECT_EQ(retrieved_path, new_path);
+}
+
+// Test FlowDumpWriter - null data handling
+TEST_F(FlowDumpTest, FlowDumpWriter_NullData)
+{
+    FlowDumpWriter& writer = FlowDumpWriter::getInstance();
+    bool success = writer.writeFlowDumpData(nullptr, 0x1000000000001);
+    ASSERT_FALSE(success);
+}
+
+// Test FlowDumpWriter - write multiple flows and verify
+TEST_F(FlowDumpTest, FlowDumpWriter_MultipleFlows)
+{
+    std::string test_dir = "/tmp/test_multiple_flows";
+    
+    // Clear any existing files in test directory
+    clearTestDirectory(test_dir);
+
+    // Set base path to test directory
+    FlowDumpWriter& writer = FlowDumpWriter::getInstance();
+    writer.setBasePath(test_dir + "/");
+
+    // Create flow dump data with multiple flows
+    FlowDumpDataPtr data = std::make_shared<FlowDumpData>();
+
+    // Flow 1: TCP flow
+    nlohmann::json flow1;
+    flow1["em"] = "AA:BB:CC:DD:EE:01";
+    flow1["vn"] = 10;
+    flow1["pr"] = 6; // TCP
+    flow1["si"] = "192.168.1.10";
+    flow1["di"] = "10.0.0.10";
+    flow1["sp"] = 8080;
+    flow1["dp"] = 443;
+    data->json_lines.push_back(flow1);
+
+    // Flow 2: UDP flow
+    nlohmann::json flow2;
+    flow2["em"] = "AA:BB:CC:DD:EE:02";
+    flow2["vn"] = 20;
+    flow2["pr"] = 17; // UDP
+    flow2["si"] = "172.16.0.1";
+    flow2["di"] = "8.8.8.8";
+    flow2["sp"] = 5353;
+    flow2["dp"] = 53;
+    data->json_lines.push_back(flow2);
+
+    // Flow 3: Another TCP flow
+    nlohmann::json flow3;
+    flow3["em"] = "AA:BB:CC:DD:EE:03";
+    flow3["vn"] = 30;
+    flow3["pr"] = 6; // TCP
+    flow3["si"] = "10.1.1.1";
+    flow3["di"] = "10.2.2.2";
+    flow3["sp"] = 12345;
+    flow3["dp"] = 80;
+    data->json_lines.push_back(flow3);
+
+    // Flow 4: ICMP-like flow (protocol 1)
+    nlohmann::json flow4;
+    flow4["em"] = "AA:BB:CC:DD:EE:04";
+    flow4["vn"] = 40;
+    flow4["pr"] = 1; // ICMP
+    flow4["si"] = "192.168.100.1";
+    flow4["di"] = "192.168.100.2";
+    flow4["sp"] = 0;
+    flow4["dp"] = 0;
+    data->json_lines.push_back(flow4);
+
+    // Flow 5: Another UDP flow
+    nlohmann::json flow5;
+    flow5["em"] = "AA:BB:CC:DD:EE:05";
+    flow5["vn"] = 50;
+    flow5["pr"] = 17; // UDP
+    flow5["si"] = "1.1.1.1";
+    flow5["di"] = "1.1.1.2";
+    flow5["sp"] = 50000;
+    flow5["dp"] = 50001;
+    data->json_lines.push_back(flow5);
+
+    // Write flow dump data
+    sai_object_id_t test_vid = 0x4000000000001;
+    bool success = writer.writeFlowDumpData(data, test_vid);
+    ASSERT_TRUE(success);
+
+    // Verify file was created
+    std::string expected_file;
+    DIR* dir = opendir(test_dir.c_str());
+    ASSERT_NE(dir, nullptr);
+    struct dirent* entry;
+    bool found = false;
+    while ((entry = readdir(dir)) != nullptr)
+    {
+        if (strncmp(entry->d_name, "flow_dump_", 10) == 0)
+        {
+            expected_file = test_dir + "/" + entry->d_name;
+            found = true;
+            break;
+        }
+    }
+    closedir(dir);
+    ASSERT_TRUE(found) << "No flow dump file found in " << test_dir;
+
+    // Verify file exists
+    struct stat file_stat;
+    ASSERT_EQ(stat(expected_file.c_str(), &file_stat), 0);
+
+    // Read and decompress the file
+    gzFile gz_file = gzopen(expected_file.c_str(), "rb");
+    ASSERT_NE(gz_file, nullptr);
+
+    char buffer[4096];
+    std::string decompressed_data;
+    int bytes_read;
+    while ((bytes_read = gzread(gz_file, buffer, sizeof(buffer) - 1)) > 0)
+    {
+        buffer[bytes_read] = '\0';
+        decompressed_data += buffer;
+    }
+    gzclose(gz_file);
+
+    // Parse the decompressed data
+    std::istringstream iss(decompressed_data);
+    std::string line;
+    std::vector<nlohmann::json> read_lines;
+
+    while (std::getline(iss, line))
+    {
+        if (!line.empty())
+        {
+            read_lines.push_back(nlohmann::json::parse(line));
+        }
+    }
+
+    // Verify we read back 5 flows
+    ASSERT_EQ(read_lines.size(), 5);
+
+    // Verify Flow 1 (TCP)
+    EXPECT_EQ(read_lines[0]["em"], "AA:BB:CC:DD:EE:01");
+    EXPECT_EQ(read_lines[0]["vn"], 10);
+    EXPECT_EQ(read_lines[0]["pr"], 6);
+    EXPECT_EQ(read_lines[0]["si"], "192.168.1.10");
+    EXPECT_EQ(read_lines[0]["di"], "10.0.0.10");
+    EXPECT_EQ(read_lines[0]["sp"], 8080);
+    EXPECT_EQ(read_lines[0]["dp"], 443);
+
+    // Verify Flow 2 (UDP)
+    EXPECT_EQ(read_lines[1]["em"], "AA:BB:CC:DD:EE:02");
+    EXPECT_EQ(read_lines[1]["vn"], 20);
+    EXPECT_EQ(read_lines[1]["pr"], 17);
+    EXPECT_EQ(read_lines[1]["si"], "172.16.0.1");
+    EXPECT_EQ(read_lines[1]["di"], "8.8.8.8");
+    EXPECT_EQ(read_lines[1]["sp"], 5353);
+    EXPECT_EQ(read_lines[1]["dp"], 53);
+
+    // Verify Flow 3 (TCP)
+    EXPECT_EQ(read_lines[2]["em"], "AA:BB:CC:DD:EE:03");
+    EXPECT_EQ(read_lines[2]["vn"], 30);
+    EXPECT_EQ(read_lines[2]["pr"], 6);
+    EXPECT_EQ(read_lines[2]["si"], "10.1.1.1");
+    EXPECT_EQ(read_lines[2]["di"], "10.2.2.2");
+    EXPECT_EQ(read_lines[2]["sp"], 12345);
+    EXPECT_EQ(read_lines[2]["dp"], 80);
+
+    // Verify Flow 4 (ICMP)
+    EXPECT_EQ(read_lines[3]["em"], "AA:BB:CC:DD:EE:04");
+    EXPECT_EQ(read_lines[3]["vn"], 40);
+    EXPECT_EQ(read_lines[3]["pr"], 1);
+    EXPECT_EQ(read_lines[3]["si"], "192.168.100.1");
+    EXPECT_EQ(read_lines[3]["di"], "192.168.100.2");
+    EXPECT_EQ(read_lines[3]["sp"], 0);
+    EXPECT_EQ(read_lines[3]["dp"], 0);
+
+    // Verify Flow 5 (UDP)
+    EXPECT_EQ(read_lines[4]["em"], "AA:BB:CC:DD:EE:05");
+    EXPECT_EQ(read_lines[4]["vn"], 50);
+    EXPECT_EQ(read_lines[4]["pr"], 17);
+    EXPECT_EQ(read_lines[4]["si"], "1.1.1.1");
+    EXPECT_EQ(read_lines[4]["di"], "1.1.1.2");
+    EXPECT_EQ(read_lines[4]["sp"], 50000);
+    EXPECT_EQ(read_lines[4]["dp"], 50001);
+
+    // Clean up
+    unlink(expected_file.c_str());
+    rmdir(test_dir.c_str());
+}
+
+// Test FlowDumpWriter - write flows with attributes and verify
+TEST_F(FlowDumpTest, FlowDumpWriter_WithAttributes)
+{
+    std::string test_dir = "/tmp/test_flows_with_attributes";
+    
+    // Clear any existing files in test directory
+    clearTestDirectory(test_dir);
+
+    // Set base path to test directory
+    FlowDumpWriter& writer = FlowDumpWriter::getInstance();
+    writer.setBasePath(test_dir + "/");
+
+    // Create flow dump data with attributes using FlowDumpSerializer
+    sai_flow_bulk_get_session_event_data_t event_data[2];
+    
+    // Flow 1: With attributes
+    event_data[0] = m_event_data;
+    sai_attribute_t attrs1[3];
+    memset(attrs1, 0, sizeof(attrs1));
+    
+    attrs1[0].id = SAI_FLOW_ENTRY_ATTR_VERSION;
+    attrs1[0].value.u32 = 100;
+    
+    attrs1[1].id = SAI_FLOW_ENTRY_ATTR_IS_UNIDIRECTIONAL_FLOW;
+    attrs1[1].value.booldata = true;
+    
+    attrs1[2].id = SAI_FLOW_ENTRY_ATTR_DST_MAC;
+    uint8_t dst_mac1[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+    memcpy(attrs1[2].value.mac, dst_mac1, 6);
+    
+    event_data[0].attr_count = 3;
+    event_data[0].attr = attrs1;
+
+    // Flow 2: With different attributes
+    event_data[1] = m_event_data;
+    event_data[1].flow_entry.vnet_id = 100;
+    event_data[1].flow_entry.src_port = 9999;
+    event_data[1].flow_entry.dst_port = 8888;
+    
+    sai_attribute_t attrs2[2];
+    memset(attrs2, 0, sizeof(attrs2));
+    
+    attrs2[0].id = SAI_FLOW_ENTRY_ATTR_VERSION;
+    attrs2[0].value.u32 = 200;
+    
+    attrs2[1].id = SAI_FLOW_ENTRY_ATTR_SIP;
+    attrs2[1].value.ipaddr.addr_family = SAI_IP_ADDR_FAMILY_IPV4;
+    attrs2[1].value.ipaddr.addr.ip4 = inet_addr("1.2.3.4");
+    
+    event_data[1].attr_count = 2;
+    event_data[1].attr = attrs2;
+
+    // Serialize to JSON lines
+    FlowDumpDataPtr data = std::make_shared<FlowDumpData>();
+    nlohmann::json json_line1 = FlowDumpSerializer::serializeFlowEntryToJson(event_data[0]);
+    nlohmann::json json_line2 = FlowDumpSerializer::serializeFlowEntryToJson(event_data[1]);
+    data->json_lines.push_back(json_line1);
+    data->json_lines.push_back(json_line2);
+    
+    ASSERT_NE(data, nullptr);
+    ASSERT_EQ(data->json_lines.size(), 2);
+
+    // Write flow dump data
+    sai_object_id_t test_vid = 0x5000000000001;
+    bool success = writer.writeFlowDumpData(data, test_vid);
+    ASSERT_TRUE(success);
+
+    // Verify file was created
+    std::string expected_file;
+    DIR* dir = opendir(test_dir.c_str());
+    ASSERT_NE(dir, nullptr);
+    struct dirent* entry;
+    bool found = false;
+    while ((entry = readdir(dir)) != nullptr)
+    {
+        if (strncmp(entry->d_name, "flow_dump_", 10) == 0)
+        {
+            expected_file = test_dir + "/" + entry->d_name;
+            found = true;
+            break;
+        }
+    }
+    closedir(dir);
+    ASSERT_TRUE(found) << "No flow dump file found in " << test_dir;
+
+    // Verify file exists
+    struct stat file_stat;
+    ASSERT_EQ(stat(expected_file.c_str(), &file_stat), 0);
+
+    // Read and decompress the file
+    gzFile gz_file = gzopen(expected_file.c_str(), "rb");
+    ASSERT_NE(gz_file, nullptr);
+
+    char buffer[4096];
+    std::string decompressed_data;
+    int bytes_read;
+    while ((bytes_read = gzread(gz_file, buffer, sizeof(buffer) - 1)) > 0)
+    {
+        buffer[bytes_read] = '\0';
+        decompressed_data += buffer;
+    }
+    gzclose(gz_file);
+
+    // Parse the decompressed data
+    std::istringstream iss(decompressed_data);
+    std::string line;
+    std::vector<nlohmann::json> read_lines;
+
+    while (std::getline(iss, line))
+    {
+        if (!line.empty())
+        {
+            read_lines.push_back(nlohmann::json::parse(line));
+        }
+    }
+
+    // Verify we read back 2 flows
+    ASSERT_EQ(read_lines.size(), 2);
+
+    // Verify Flow 1 with attributes
+    EXPECT_EQ(read_lines[0]["vn"], 1);
+    EXPECT_EQ(read_lines[0]["sp"], 12345);
+    EXPECT_EQ(read_lines[0]["dp"], 80);
+    
+    std::string attr_version_key1 = std::to_string(SAI_FLOW_ENTRY_ATTR_VERSION);
+    std::string attr_unidirectional_key = std::to_string(SAI_FLOW_ENTRY_ATTR_IS_UNIDIRECTIONAL_FLOW);
+    std::string attr_dst_mac_key = std::to_string(SAI_FLOW_ENTRY_ATTR_DST_MAC);
+    
+    ASSERT_TRUE(read_lines[0].contains(attr_version_key1));
+    EXPECT_EQ(read_lines[0][attr_version_key1], "100");  // Serialized as string
+    
+    ASSERT_TRUE(read_lines[0].contains(attr_unidirectional_key));
+    EXPECT_EQ(read_lines[0][attr_unidirectional_key], "true");  // Serialized as string
+    
+    ASSERT_TRUE(read_lines[0].contains(attr_dst_mac_key));
+    EXPECT_EQ(read_lines[0][attr_dst_mac_key], "11:22:33:44:55:66");
+
+    // Verify Flow 2 with attributes
+    EXPECT_EQ(read_lines[1]["vn"], 100);
+    EXPECT_EQ(read_lines[1]["sp"], 9999);
+    EXPECT_EQ(read_lines[1]["dp"], 8888);
+    
+    std::string attr_version_key2 = std::to_string(SAI_FLOW_ENTRY_ATTR_VERSION);
+    std::string attr_sip_key = std::to_string(SAI_FLOW_ENTRY_ATTR_SIP);
+    
+    ASSERT_TRUE(read_lines[1].contains(attr_version_key2));
+    EXPECT_EQ(read_lines[1][attr_version_key2], "200");  // Serialized as string
+    
+    ASSERT_TRUE(read_lines[1].contains(attr_sip_key));
+    EXPECT_EQ(read_lines[1][attr_sip_key], "1.2.3.4");
+
+    // Clean up
+    unlink(expected_file.c_str());
+    rmdir(test_dir.c_str());
+}
+
+// Test FlowDumpWriter - logrotate functionality
+TEST_F(FlowDumpTest, FlowDumpWriter_LogRotate)
+{
+    std::string test_dir = "/tmp/test_logrotate";
+    
+    // Clear any existing files in test directory
+    clearTestDirectory(test_dir);
+
+    // Set base path to test directory
+    FlowDumpWriter& writer = FlowDumpWriter::getInstance();
+    writer.setBasePath(test_dir + "/");
+
+    // Create flow dump data
+    FlowDumpDataPtr data = std::make_shared<FlowDumpData>();
+    nlohmann::json json_line;
+    json_line["em"] = "00:11:22:33:44:55";
+    json_line["vn"] = 1;
+    json_line["pr"] = 6;
+    json_line["si"] = "10.10.10.10";
+    json_line["di"] = "192.168.0.1";
+    json_line["sp"] = 12345;
+    json_line["dp"] = 80;
+    data->json_lines.push_back(json_line);
+
+    // Create first file - should work fine
+    sai_object_id_t vid1 = 0x6000000000001;
+    bool success1 = writer.writeFlowDumpData(data, vid1);
+    ASSERT_TRUE(success1);
+
+    // Small delay to ensure different modification times
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    // Create second file - should work fine (we have MAX_FILES = 2)
+    sai_object_id_t vid2 = 0x6000000000002;
+    bool success2 = writer.writeFlowDumpData(data, vid2);
+    ASSERT_TRUE(success2);
+
+    // Get the actual file paths that were created
+    std::vector<std::pair<std::string, std::time_t>> files_before;
+    
+    DIR* dir = opendir(test_dir.c_str());
+    ASSERT_NE(dir, nullptr);
+    struct dirent* entry;
+    struct stat st;
+    while ((entry = readdir(dir)) != nullptr)
+    {
+        if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+        {
+            continue;
+        }
+        
+        std::string filename = entry->d_name;
+        if (filename.find(FlowDumpWriter::FLOW_DUMP_FILE_PREFIX) == 0 && filename.find(FlowDumpWriter::FLOW_DUMP_FILE_SUFFIX) != std::string::npos)
+        {
+            std::string full_path = test_dir;
+            if (full_path.back() != '/')
+            {
+                full_path += '/';
+            }
+            full_path += filename;
+            
+            if (stat(full_path.c_str(), &st) == 0 && S_ISREG(st.st_mode))
+            {
+                files_before.push_back(std::make_pair(full_path, st.st_mtime));
+            }
+        }
+    }
+    closedir(dir);
+    ASSERT_EQ(files_before.size(), 2) << "Expected 2 files after creating second file";
+    
+    // Sort files by modification time to identify oldest
+    std::sort(files_before.begin(), files_before.end(),
+              [](const std::pair<std::string, std::time_t>& a, const std::pair<std::string, std::time_t>& b) {
+                  return a.second < b.second;
+              });
+    
+    // The first file in the sorted list is the oldest (vid1)
+    std::string file1_path = files_before[0].first;
+    std::string file2_path = files_before[1].first;
+
+    // Small delay to ensure different modification times
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    // Create third file - should delete the first file (oldest)
+    sai_object_id_t vid3 = 0x6000000000003;
+    bool success3 = writer.writeFlowDumpData(data, vid3);
+    ASSERT_TRUE(success3);
+
+    // Verify only 2 files exist now (second and third, first should be deleted)
+    std::vector<std::string> files_after;
+    dir = opendir(test_dir.c_str());
+    ASSERT_NE(dir, nullptr);
+    while ((entry = readdir(dir)) != nullptr)
+    {
+        if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0)
+        {
+            continue;
+        }
+        
+        std::string filename = entry->d_name;
+        if (filename.find(FlowDumpWriter::FLOW_DUMP_FILE_PREFIX) == 0 && filename.find(FlowDumpWriter::FLOW_DUMP_FILE_SUFFIX) != std::string::npos)
+        {
+            std::string full_path = test_dir;
+            if (full_path.back() != '/')
+            {
+                full_path += '/';
+            }
+            full_path += filename;
+            
+            if (stat(full_path.c_str(), &st) == 0 && S_ISREG(st.st_mode))
+            {
+                files_after.push_back(full_path);
+            }
+        }
+    }
+    closedir(dir);
+    ASSERT_EQ(files_after.size(), 2) << "Expected 2 files after creating third file (logrotate should have deleted oldest)";
+
+    // Verify the first file (oldest) was deleted
+    struct stat file_stat;
+    ASSERT_NE(stat(file1_path.c_str(), &file_stat), 0) << "First file (oldest) should have been deleted";
+
+    // Verify the second file still exists
+    ASSERT_EQ(stat(file2_path.c_str(), &file_stat), 0) << "Second file should still exist";
+
+    // Verify file1_path is not in the remaining files
+    ASSERT_EQ(std::find(files_after.begin(), files_after.end(), file1_path), files_after.end()) 
+        << "First file should not be in remaining files";
+    
+    // Verify file2_path is in the remaining files
+    ASSERT_NE(std::find(files_after.begin(), files_after.end(), file2_path), files_after.end()) 
+        << "Second file should be in remaining files";
+
+    // Clean up
+    for (const auto& file : files_after)
+    {
+        unlink(file.c_str());
+    }
+    rmdir(test_dir.c_str());
+}
+
+// Test FlowDumpSerializer::serializeAttributeValue with enum types
+TEST_F(FlowDumpTest, FlowDumpSerializer_AttributeValue_EnumTypes)
+{
+    sai_flow_bulk_get_session_event_data_t event_data = m_event_data;
+
+    // Set up attributes with enum types
+    sai_attribute_t attrs[5];
+    memset(attrs, 0, sizeof(attrs));
+
+    // Attribute 1: DASH direction (enum - sai_dash_direction_t)
+    attrs[0].id = SAI_FLOW_ENTRY_ATTR_DASH_DIRECTION;
+    attrs[0].value.s32 = SAI_DASH_DIRECTION_OUTBOUND;
+
+    // Attribute 2: DASH flow action (enum - sai_dash_flow_action_t)
+    attrs[1].id = SAI_FLOW_ENTRY_ATTR_DASH_FLOW_ACTION;
+    attrs[1].value.s32 = SAI_DASH_FLOW_ACTION_ENCAP_U1;
+
+    // Attribute 3: DASH encapsulation (enum - sai_dash_encapsulation_t)
+    attrs[2].id = SAI_FLOW_ENTRY_ATTR_UNDERLAY0_DASH_ENCAPSULATION;
+    attrs[2].value.s32 = SAI_DASH_ENCAPSULATION_VXLAN;
+
+    // Attribute 4: DASH flow sync state (enum - sai_dash_flow_sync_state_t)
+    attrs[3].id = SAI_FLOW_ENTRY_ATTR_DASH_FLOW_SYNC_STATE;
+    attrs[3].value.s32 = SAI_DASH_FLOW_SYNC_STATE_FLOW_PENDING_DELETE;
+
+    // Attribute 5: IP address family (enum - sai_ip_addr_family_t)
+    attrs[4].id = SAI_FLOW_ENTRY_ATTR_IP_ADDR_FAMILY;
+    attrs[4].value.s32 = SAI_IP_ADDR_FAMILY_IPV4;
+
+    event_data.attr_count = 5;
+    event_data.attr = attrs;
+
+    nlohmann::json json_line = FlowDumpSerializer::serializeFlowEntryToJson(event_data);
+
+    // Verify enum attributes are serialized as strings (not numbers)
+    std::string attr_direction_key = std::to_string(SAI_FLOW_ENTRY_ATTR_DASH_DIRECTION);
+    std::string attr_flow_action_key = std::to_string(SAI_FLOW_ENTRY_ATTR_DASH_FLOW_ACTION);
+    std::string attr_encap_key = std::to_string(SAI_FLOW_ENTRY_ATTR_UNDERLAY0_DASH_ENCAPSULATION);
+    std::string attr_sync_state_key = std::to_string(SAI_FLOW_ENTRY_ATTR_DASH_FLOW_SYNC_STATE);
+    std::string attr_ip_family_key = std::to_string(SAI_FLOW_ENTRY_ATTR_IP_ADDR_FAMILY);
+
+    // Check that attributes exist and are strings (enum serialization returns strings)
+    ASSERT_TRUE(json_line.contains(attr_direction_key));
+    EXPECT_TRUE(json_line[attr_direction_key].is_string());
+    EXPECT_EQ(json_line[attr_direction_key], "SAI_DASH_DIRECTION_OUTBOUND");
+
+    ASSERT_TRUE(json_line.contains(attr_flow_action_key));
+    EXPECT_TRUE(json_line[attr_flow_action_key].is_string());
+    EXPECT_EQ(json_line[attr_flow_action_key], "SAI_DASH_FLOW_ACTION_ENCAP_U1");
+
+    ASSERT_TRUE(json_line.contains(attr_encap_key));
+    EXPECT_TRUE(json_line[attr_encap_key].is_string());
+    EXPECT_EQ(json_line[attr_encap_key], "SAI_DASH_ENCAPSULATION_VXLAN");
+
+    ASSERT_TRUE(json_line.contains(attr_sync_state_key));
+    EXPECT_TRUE(json_line[attr_sync_state_key].is_string());
+    EXPECT_EQ(json_line[attr_sync_state_key], "SAI_DASH_FLOW_SYNC_STATE_FLOW_PENDING_DELETE");
+
+    ASSERT_TRUE(json_line.contains(attr_ip_family_key));
+    EXPECT_TRUE(json_line[attr_ip_family_key].is_string());
+    EXPECT_EQ(json_line[attr_ip_family_key], "SAI_IP_ADDR_FAMILY_IPV4");
+}
+
+// Test FlowDumpSerializer::serializeAttributeValue with sai_u8_list_t
+TEST_F(FlowDumpTest, FlowDumpSerializer_AttributeValue_U8List)
+{
+    sai_flow_bulk_get_session_event_data_t event_data = m_event_data;
+
+    // Set up attributes with u8_list type
+    sai_attribute_t attrs[2];
+    memset(attrs, 0, sizeof(attrs));
+
+    // Attribute 1: Vendor metadata (sai_u8_list_t)
+    uint8_t vendor_metadata_buffer[5] = {0x01, 0x02, 0x03, 0x04, 0x05};
+    attrs[0].id = SAI_FLOW_ENTRY_ATTR_VENDOR_METADATA;
+    attrs[0].value.u8list.count = 5;
+    attrs[0].value.u8list.list = vendor_metadata_buffer;
+
+    // Attribute 2: Flow data protocol buffer (sai_u8_list_t)
+    uint8_t flow_data_buffer[4] = {0xAA, 0xBB, 0xCC, 0xDD};
+    attrs[1].id = SAI_FLOW_ENTRY_ATTR_FLOW_DATA_PB;
+    attrs[1].value.u8list.count = 4;
+    attrs[1].value.u8list.list = flow_data_buffer;
+
+    event_data.attr_count = 2;
+    event_data.attr = attrs;
+
+    nlohmann::json json_line = FlowDumpSerializer::serializeFlowEntryToJson(event_data);
+
+    std::string attr_vendor_metadata_key = std::to_string(SAI_FLOW_ENTRY_ATTR_VENDOR_METADATA);
+    std::string attr_flow_data_pb_key = std::to_string(SAI_FLOW_ENTRY_ATTR_FLOW_DATA_PB);
+
+    ASSERT_TRUE(json_line.contains(attr_vendor_metadata_key));
+    EXPECT_TRUE(json_line[attr_vendor_metadata_key].is_string());
+    EXPECT_EQ(json_line[attr_vendor_metadata_key], "5:1,2,3,4,5");
+
+    ASSERT_TRUE(json_line.contains(attr_flow_data_pb_key));
+    EXPECT_TRUE(json_line[attr_flow_data_pb_key].is_string());
+    EXPECT_EQ(json_line[attr_flow_data_pb_key], "4:170,187,204,221");
+}
+
+// Test FlowDumpSerializer::serializeAttributeValue exception handling
+TEST_F(FlowDumpTest, FlowDumpSerializer_AttributeValue_ExceptionHandling)
+{
+    // Test with null metadata
+    sai_attribute_t attr;
+    memset(&attr, 0, sizeof(attr));
+    attr.id = SAI_FLOW_ENTRY_ATTR_VERSION;
+    attr.value.u32 = 12345;
+
+    std::string result = FlowDumpSerializer::serializeAttributeValue(attr, nullptr);
+    EXPECT_EQ(result, "");
+
+    // Test with valid metadata
+    auto meta = sai_metadata_get_attr_metadata(static_cast<sai_object_type_t>(SAI_OBJECT_TYPE_FLOW_ENTRY), SAI_FLOW_ENTRY_ATTR_VERSION);
+    ASSERT_NE(meta, nullptr);
+    result = FlowDumpSerializer::serializeAttributeValue(attr, meta);
+    EXPECT_EQ(result, "12345");
+}
+

--- a/unittest/syncd/TestNotificationHandler.cpp
+++ b/unittest/syncd/TestNotificationHandler.cpp
@@ -3,6 +3,7 @@
 #include "meta/sai_serialize.h"
 
 #include <gtest/gtest.h>
+#include <cstring>
 
 using namespace syncd;
 
@@ -119,4 +120,27 @@ TEST(NotificationHandler, NotificationMacsecPostStatusTest)
     std::string macsecPostStatusData = "{\"macsec_id\":\"oid:0x5800000000\",\"macsec_post_status\":\"SAI_MACSEC_POST_STATUS_PASS\"}";
     sai_deserialize_macsec_post_status_ntf(macsecPostStatusData, macsec_id, macsec_post_status);
     notificationHandler->onMacsecPostStatus(macsec_id, macsec_post_status);
+}
+
+TEST(NotificationHandler, NotificationFlowBulkGetSessionEventTest)
+{
+    auto notificationProcessor =
+      std::make_shared<NotificationProcessor>(nullptr, nullptr, nullptr);
+    auto notificationHandler =
+      std::make_shared<NotificationHandler>(notificationProcessor);
+
+    sai_attribute_t attr;
+    attr.id = SAI_SWITCH_ATTR_FLOW_BULK_GET_SESSION_EVENT_NOTIFY;
+    attr.value.ptr = (void *) 1;
+    notificationHandler->updateNotificationsPointers(1, &attr);
+
+    sai_object_id_t flow_bulk_session_id = 0x123456789abcdef;
+    uint32_t count = 1;
+    sai_flow_bulk_get_session_event_data_t event_data[1];
+    event_data[0].event_type = SAI_FLOW_BULK_GET_SESSION_EVENT_FINISHED;
+    event_data[0].attr_count = 0;
+    event_data[0].attr = nullptr;
+    memset(&event_data[0].flow_entry, 0, sizeof(event_data[0].flow_entry));
+
+    notificationHandler->onFlowBulkGetSessionEvent(flow_bulk_session_id, count, event_data);
 }

--- a/unittest/syncd/TestNotificationProcessor.cpp
+++ b/unittest/syncd/TestNotificationProcessor.cpp
@@ -135,4 +135,12 @@ TEST(NotificationProcessor, NotificationProcessorTest)
     translator->insertRidAndVid(0x5800000000, 0x5800000000);
     notificationProcessor->syncProcessNotification(macsecPostStatusItem);
     translator->eraseRidAndVid(0x5800000000, 0x5800000000);
+
+    // Test FLOW_BULK_GET_SESSION_EVENT notification
+    std::string flowBulkGetSessionEventData = "{\"bulk_session_id\":\"oid:0x123456789abcdef\",\"data\":[{\"event_type\":\"SAI_FLOW_BULK_GET_SESSION_EVENT_FINISHED\"}]}";
+    std::vector<swss::FieldValueTuple> flowBulkGetSessionEventEntry;
+    swss::KeyOpFieldsValuesTuple flowBulkGetSessionEventItem(SAI_SWITCH_NOTIFICATION_NAME_FLOW_BULK_GET_SESSION_EVENT, flowBulkGetSessionEventData, flowBulkGetSessionEventEntry);
+    translator->insertRidAndVid(0x123456789abcdef, 0x123456789abcdef);
+    notificationProcessor->syncProcessNotification(flowBulkGetSessionEventItem);
+    translator->eraseRidAndVid(0x123456789abcdef, 0x123456789abcdef);
 }

--- a/vslib/SwitchStateBase.cpp
+++ b/vslib/SwitchStateBase.cpp
@@ -1146,6 +1146,10 @@ sai_status_t SwitchStateBase::set_switch_default_attributes()
 
     CHECK_STATUS(set(SAI_OBJECT_TYPE_SWITCH, m_switch_id, &attr));
 
+    attr.id = SAI_SWITCH_ATTR_FLOW_BULK_GET_SESSION_EVENT_NOTIFY;
+
+    CHECK_STATUS(set(SAI_OBJECT_TYPE_SWITCH, m_switch_id, &attr));
+
     attr.id = SAI_SWITCH_ATTR_TAM_TEL_TYPE_CONFIG_CHANGE_NOTIFY;
 
     CHECK_STATUS(set(SAI_OBJECT_TYPE_SWITCH, m_switch_id, &attr));


### PR DESCRIPTION
HLD: `https://github.com/sonic-net/SONiC/pull/2168`

1. Add support for Flow Bulk Session get notification
2. Flow Dump events are directly written to a file from syncd and not relayed to orchgent
3. Only FINISHED_EVENT's are relayed to orchagent
4. Add UT's and verified by creating session events

```
Note: Google Test filter = *Flow*
[==========] Running 5 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 5 tests from NotificationFlowBulkGetSessionEvent
[ RUN      ] NotificationFlowBulkGetSessionEvent.ctr
[       OK ] NotificationFlowBulkGetSessionEvent.ctr (0 ms)
[ RUN      ] NotificationFlowBulkGetSessionEvent.getSwitchId
[       OK ] NotificationFlowBulkGetSessionEvent.getSwitchId (0 ms)
[ RUN      ] NotificationFlowBulkGetSessionEvent.getAnyObjectId
[       OK ] NotificationFlowBulkGetSessionEvent.getAnyObjectId (0 ms)
[ RUN      ] NotificationFlowBulkGetSessionEvent.processMetadata
[       OK ] NotificationFlowBulkGetSessionEvent.processMetadata (0 ms)
[ RUN      ] NotificationFlowBulkGetSessionEvent.executeCallback
[       OK ] NotificationFlowBulkGetSessionEvent.executeCallback (0 ms)
[----------] 5 tests from NotificationFlowBulkGetSessionEvent (0 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 5 tests.

vkarri@300929d3c803:/sonic/src/sonic-sairedis/unittest/syncd$ ./tests --gtest_filter="*Flow*"
Note: Google Test filter = *Flow*
[==========] Running 15 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 1 test from NotificationHandler
[ RUN      ] NotificationHandler.NotificationFlowBulkGetSessionEventTest
[       OK ] NotificationHandler.NotificationFlowBulkGetSessionEventTest (0 ms)
[----------] 1 test from NotificationHandler (0 ms total)

[----------] 14 tests from FlowDumpTest
[ RUN      ] FlowDumpTest.FlowDumpSerializer_SingleFlowEntry
[       OK ] FlowDumpTest.FlowDumpSerializer_SingleFlowEntry (0 ms)
[ RUN      ] FlowDumpTest.FlowDumpSerializer_MultipleFlowEntries
[       OK ] FlowDumpTest.FlowDumpSerializer_MultipleFlowEntries (0 ms)
[ RUN      ] FlowDumpTest.FlowDumpSerializer_FinishedEvent
[       OK ] FlowDumpTest.FlowDumpSerializer_FinishedEvent (0 ms)
[ RUN      ] FlowDumpTest.FlowDumpSerializer_WithAttributes
[       OK ] FlowDumpTest.FlowDumpSerializer_WithAttributes (0 ms)
[ RUN      ] FlowDumpTest.FlowDumpWriter_WriteAndRead
[       OK ] FlowDumpTest.FlowDumpWriter_WriteAndRead (0 ms)
[ RUN      ] FlowDumpTest.FlowDumpWriter_FilePathGeneration
[       OK ] FlowDumpTest.FlowDumpWriter_FilePathGeneration (0 ms)
[ RUN      ] FlowDumpTest.FlowDumpWriter_BasePathGetterSetter
[       OK ] FlowDumpTest.FlowDumpWriter_BasePathGetterSetter (0 ms)
[ RUN      ] FlowDumpTest.FlowDumpWriter_NullData
[       OK ] FlowDumpTest.FlowDumpWriter_NullData (0 ms)
[ RUN      ] FlowDumpTest.FlowDumpWriter_MultipleFlows
[       OK ] FlowDumpTest.FlowDumpWriter_MultipleFlows (0 ms)
[ RUN      ] FlowDumpTest.FlowDumpWriter_WithAttributes
[       OK ] FlowDumpTest.FlowDumpWriter_WithAttributes (0 ms)
[ RUN      ] FlowDumpTest.FlowDumpWriter_LogRotate
[       OK ] FlowDumpTest.FlowDumpWriter_LogRotate (201 ms)
[ RUN      ] FlowDumpTest.FlowDumpSerializer_AttributeValue_EnumTypes
[       OK ] FlowDumpTest.FlowDumpSerializer_AttributeValue_EnumTypes (0 ms)
[ RUN      ] FlowDumpTest.FlowDumpSerializer_AttributeValue_U8List
[       OK ] FlowDumpTest.FlowDumpSerializer_AttributeValue_U8List (0 ms)
[ RUN      ] FlowDumpTest.FlowDumpSerializer_AttributeValue_ExceptionHandling
[       OK ] FlowDumpTest.FlowDumpSerializer_AttributeValue_ExceptionHandling (0 ms)
[----------] 14 tests from FlowDumpTest (203 ms total)

[----------] Global test environment tear-down
[==========] 15 tests from 2 test suites ran. (203 ms total)
[  PASSED  ] 15 tests.
```